### PR TITLE
Ignore errors when trying to remove .sicc-version

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -63,7 +63,7 @@ func applyRepo(fs afero.Fs, p *plan.Plan, repoBox *packr.Box) error {
 	if !p.SiccMode {
 		e := fs.Remove(".sicc-version")
 		if e != nil {
-			log.Println("error removing .sicc-version. ignoring")
+			log.Debug("error removing .sicc-version. ignoring")
 		}
 	}
 	return nil


### PR DESCRIPTION
Fogg currently fails when .sicc-version doesn't exist.

```
PANI unable to apply repo: remove /Users/alin/code/ws-infra/.sicc-version: no such file or directory
panic: (*logrus.Entry) (0x1a3aae0,0xc4204400a0)

goroutine 1 [running]:
github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus.Entry.log(0xc4200aae60, 0xc42042a150, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus/entry.go:112 +0x254
github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus.(*Entry).Panic(0xc420440000, 0xc4201ffc70, 0x1, 0x1)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus/entry.go:182 +0xaa
github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus.(*Logger).Panic(0xc4200aae60, 0xc4201ffc70, 0x1, 0x1)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus/logger.go:236 +0x6d
github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus.Panic(0xc4201ffc70, 0x1, 0x1)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/sirupsen/logrus/exported.go:107 +0x4b
github.com/chanzuckerberg/fogg/cmd.glob..func1(0x2071780, 0x209a288, 0x0, 0x0)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/cmd/apply.go:70 +0x373
github.com/chanzuckerberg/fogg/vendor/github.com/spf13/cobra.(*Command).execute(0x2071780, 0x209a288, 0x0, 0x0, 0x2071780, 0x209a288)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/spf13/cobra/command.go:766 +0x2c1
github.com/chanzuckerberg/fogg/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x2071ea0, 0x102a2a9, 0x1a8b940, 0xc4201fff30)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/chanzuckerberg/fogg/vendor/github.com/spf13/cobra.(*Command).Execute(0x2071ea0, 0x12fc532, 0xc4200aae8c)
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/chanzuckerberg/fogg/cmd.Execute()
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/cmd/root.go:29 +0x2d
main.main()
    /Users/alin/go/src/github.com/chanzuckerberg/fogg/main.go:13 +0x50
```