### PR TITLE
fix cloud-env module

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -348,7 +348,7 @@ func buildEnvs(conf *config.Config, siccMode bool) map[string]Env {
 			componentPlan.OtherComponents = []string{}
 			componentPlan.SiccMode = siccMode
 
-			componentPlan.BootstrapModule = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/aws-env"
+			componentPlan.BootstrapModule = fmt.Sprintf("git@github.com:chanzuckerberg/shared-infra//terraform/modules/aws-env?ref=%s", componentPlan.SharedInfraVersion)
 
 			envPlan.Components["cloud-env"] = componentPlan
 		}


### PR DESCRIPTION
We need to put the shared infra version in here.

Note that this is code just to handle the transition to fogg. Once we've moved we will make the module application process generic.