### PR TITLE
remove shared_infra_version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,6 @@ type defaults struct {
 	InfraBucket        string   `json:"infra_s3_bucket" validate:"required"`
 	Owner              string   `json:"owner" validate:"required"`
 	Project            string   `json:"project" validate:"required"`
-	SharedInfraVersion string   `json:"shared_infra_version" validate:"required"`
 	TerraformVersion   string   `json:"terraform_version" validate:"required"`
 }
 
@@ -69,7 +68,6 @@ type Component struct {
 	InfraBucket        *string  `json:"infra_s3_bucket"`
 	Owner              *string  `json:"owner"`
 	Project            *string  `json:"project"`
-	SharedInfraVersion *string  `json:"shared_infra_version"`
 	ModuleSource       *string  `json:"module_source"`
 	TerraformVersion   *string  `json:"terraform_version"`
 }
@@ -103,7 +101,7 @@ var allRegions = []string{
 	"us-west-2",
 }
 
-func InitConfig(project, region, bucket, awsProfile, owner, sharedInfraVersion, awsProviderVersion string) *Config {
+func InitConfig(project, region, bucket, awsProfile, owner, awsProviderVersion string) *Config {
 	return &Config{
 		Defaults: defaults{
 			AWSProfileBackend:  awsProfile,
@@ -115,7 +113,6 @@ func InitConfig(project, region, bucket, awsProfile, owner, sharedInfraVersion, 
 			Owner:              owner,
 			Project:            project,
 			TerraformVersion:   "0.11.7",
-			SharedInfraVersion: sharedInfraVersion,
 		},
 		Accounts: map[string]Account{},
 		Envs:     map[string]Env{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -96,11 +96,11 @@ func TestValidation(t *testing.T) {
 
 	err, ok := e.(validator.ValidationErrors)
 	assert.True(t, ok)
-	assert.Len(t, err, 10)
+	assert.Len(t, err, 9)
 }
 
 func TestInitConfig(t *testing.T) {
-	c := InitConfig("proj", "reg", "buck", "prof", "me@foo.example", "0.100.0", "0.99.0")
+	c := InitConfig("proj", "reg", "buck", "prof", "me@foo.example", "0.99.0")
 	assert.Equal(t, "prof", c.Defaults.AWSProfileBackend)
 	assert.Equal(t, "prof", c.Defaults.AWSProfileProvider)
 	assert.Equal(t, "reg", c.Defaults.AWSRegionBackend)
@@ -110,5 +110,4 @@ func TestInitConfig(t *testing.T) {
 	assert.Equal(t, "me@foo.example", c.Defaults.Owner)
 	assert.Equal(t, "proj", c.Defaults.Project)
 	assert.Equal(t, "0.11.7", c.Defaults.TerraformVersion)
-	assert.Equal(t, "0.100.0", c.Defaults.SharedInfraVersion)
 }

--- a/config/fixtures/full.json
+++ b/config/fixtures/full.json
@@ -9,7 +9,6 @@
     "infra_s3_bucket": "the-bucket",
     "owner": "default@example.com",
     "project": "test-project",
-    "shared_infra_version": "0.1.0",
     "terraform_version": "0.11.0"
   },
   "accounts": {

--- a/init/init.go
+++ b/init/init.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-const DefaultSharedInfraVersion = "0.10.0"
 const AWSProviderVersion = "1.27.0"
 
 func userPrompt() (string, string, string, string, string) {
@@ -37,7 +36,7 @@ func writeConfig(fs afero.Fs, config *config.Config) error {
 
 func Init(fs afero.Fs) error {
 	project, region, bucket, profile, owner := userPrompt()
-	config := config.InitConfig(project, region, bucket, profile, owner, DefaultSharedInfraVersion, AWSProviderVersion)
+	config := config.InitConfig(project, region, bucket, profile, owner, AWSProviderVersion)
 	e := writeConfig(fs, config)
 	return e
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -45,7 +45,6 @@ type Component struct {
 	OtherComponents    []string
 	Owner              string
 	Project            string
-	SharedInfraVersion string
 	TerraformVersion   string
 	SiccMode           bool
 
@@ -178,7 +177,6 @@ func Print(p *Plan) error {
 			fmt.Printf("\t\t\t\tother_components: %v\n", component.OtherComponents)
 			fmt.Printf("\t\t\t\towner: %v\n", component.Owner)
 			fmt.Printf("\t\t\t\tproject: %v\n", component.Project)
-			fmt.Printf("\t\t\t\tshared_infra_version: %v\n", component.SharedInfraVersion)
 			fmt.Printf("\t\t\t\tterraform_version: %v\n", component.TerraformVersion)
 		}
 
@@ -306,7 +304,6 @@ func buildEnvs(conf *config.Config, siccMode bool) map[string]Env {
 			componentPlan.InfraBucket = resolveRequired(envPlan.InfraBucket, componentConf.InfraBucket)
 			componentPlan.Owner = resolveRequired(envPlan.Owner, componentConf.Owner)
 			componentPlan.Project = resolveRequired(envPlan.Project, componentConf.Project)
-			componentPlan.SharedInfraVersion = resolveRequired(conf.Defaults.SharedInfraVersion, componentConf.SharedInfraVersion)
 
 			componentPlan.Env = envName
 			componentPlan.Component = componentName


### PR DESCRIPTION
Since we made the cloud-env mechanism generic, we don't need this anymore.

Fixes #95