### PR TITLE
fix file modes

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -190,10 +190,7 @@ func applyTree(source *packr.Box, dest afero.Fs, targetBasePath string, siccMode
 				return errors.Wrap(e, "unable to format HCL")
 			}
 		}
-		// Some output files need to be executable, but we lose all file mode info
-		// when the files get put in a Box. This is a blunt instrument to make
-		// sure those work
-		return dest.Chmod(target, 0744)
+		return nil
 	})
 }
 

--- a/templates/account/Makefile.tmpl
+++ b/templates/account/Makefile.tmpl
@@ -12,7 +12,7 @@ docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
-	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$($(REPO_ROOT)/scripts/docker-ssh-mount.sh)
+	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
 docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
 
@@ -62,7 +62,7 @@ check-plan: init get ssh-forward
 	fi
 
 ssh-forward:
-	$(REPO_ROOT)/scripts/docker-ssh-forward.sh
+	sh $(REPO_ROOT)/scripts/docker-ssh-forward.sh
 
 run:
 	$(docker_terraform) $(CMD)

--- a/templates/component/Makefile.tmpl
+++ b/templates/component/Makefile.tmpl
@@ -12,7 +12,7 @@ docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
-	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$($(REPO_ROOT)/scripts/docker-ssh-mount.sh)
+	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
 docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
 
@@ -62,7 +62,7 @@ check-plan: init get ssh-forward
 	fi
 
 ssh-forward:
-	$(REPO_ROOT)/scripts/docker-ssh-forward.sh
+	sh $(REPO_ROOT)/scripts/docker-ssh-forward.sh
 
 run:
 	$(docker_terraform) $(CMD)

--- a/templates/global/Makefile.tmpl
+++ b/templates/global/Makefile.tmpl
@@ -12,7 +12,7 @@ docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
-	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$($(REPO_ROOT)/scripts/docker-ssh-mount.sh)
+	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
 docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
 
@@ -62,7 +62,7 @@ check-plan: init get ssh-forward
 	fi
 
 ssh-forward:
-	$(REPO_ROOT)/scripts/docker-ssh-forward.sh
+	sh $(REPO_ROOT)/scripts/docker-ssh-forward.sh
 
 run:
 	$(docker_terraform) $(CMD)

--- a/templates/module/Makefile.tmpl
+++ b/templates/module/Makefile.tmpl
@@ -12,7 +12,7 @@ docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
-	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$($(REPO_ROOT)/scripts/docker-ssh-mount.sh)
+	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
 docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
 

--- a/templates/repo/Makefile.tmpl
+++ b/templates/repo/Makefile.tmpl
@@ -7,10 +7,7 @@ ACCOUNTS={{ .Accounts | dict | keys | sortAlpha | join " "}}
 
 figlet_docker = docker run -it --rm mbentley/figlet
 
-all: setup lint
-
-setup:
-	./scripts/install_or_update.sh brew packer
+all: check
 
 lint: lint-terraform
 


### PR DESCRIPTION
After this we will no longer chmod files to be executable. The scripts that need to be
can be run with 'sh'.

I tested this on shared-infra and it appears to work fine with `make docs`.

fixes #77 