### PR TITLE
fix lint

### DIFF
--- a/templates/account/Makefile.tmpl
+++ b/templates/account/Makefile.tmpl
@@ -25,8 +25,7 @@ fmt:
 lint: lint-tf
 
 lint-tf:
-	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'; \
-	echo
+	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'
 
 get: ssh-forward
 	$(docker_terraform) get --update=true

--- a/templates/component/Makefile.tmpl
+++ b/templates/component/Makefile.tmpl
@@ -25,8 +25,7 @@ fmt:
 lint: lint-tf
 
 lint-tf:
-	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'; \
-	echo
+	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'
 
 get: ssh-forward
 	$(docker_terraform) get --update=true

--- a/templates/env/Makefile.tmpl
+++ b/templates/env/Makefile.tmpl
@@ -8,13 +8,11 @@ all:
 
 lint:
 	@for c in $(COMPONENTS); do \
-		$(figlet_docker) "envs/{{ .Env }}/$$c"; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 
 fmt:
 	@for c in $(COMPONENTS); do \
-		$(figlet_docker) "envs/{{ .Env }}/$$c"; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 

--- a/templates/global/Makefile.tmpl
+++ b/templates/global/Makefile.tmpl
@@ -25,8 +25,7 @@ fmt:
 lint: lint-tf
 
 lint-tf:
-	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'; \
-	echo
+	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'
 
 get: ssh-forward
 	$(docker_terraform) get --update=true

--- a/templates/module/Makefile.tmpl
+++ b/templates/module/Makefile.tmpl
@@ -25,8 +25,7 @@ fmt:
 lint: lint-tf
 
 lint-tf:
-	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'; \
-	echo
+	@$(docker_sh) -c 'for f in $(TF); do printf .; terraform fmt --check=true --diff=true $$f || exit $$? ; done'
 
 readme:
 	bash .update-readme.sh update

--- a/templates/repo/Makefile.tmpl
+++ b/templates/repo/Makefile.tmpl
@@ -15,13 +15,11 @@ lint-terraform: lint-accounts lint-envs lint-modules
 
 lint-accounts:
 	@for account in $(ACCOUNTS); do \
-		$(figlet_docker) "account/$$account"; \
 		$(MAKE) -C terraform/accounts/$$account lint || exit $$?; \
 	done
 
 lint-envs:
 	@for env in $(ENVS); do \
-		$(figlet_docker) "envs/$$env"; \
 		$(MAKE) -C terraform/envs/$$env lint || exit $$?; \
 	done; \
 	$(figlet_docker) "global"; \
@@ -29,7 +27,6 @@ lint-envs:
 
 lint-modules:
 	@for module in $(MODULES); do \
-		$(figlet_docker) "modules/$$module"; \
 		$(MAKE) -C terraform/modules/$$module lint || exit $$?; \
 	done
 
@@ -37,23 +34,19 @@ fmt: fmt-accounts fmt-envs fmt-global fmt-modules
 
 fmt-accounts:
 	@for account in $(ACCOUNTS); do \
-		$(figlet_docker) "account/$$account"; \
 		$(MAKE) -C terraform/accounts/$$account fmt || exit $$?; \
 	done
 
 fmt-envs:
 	@for env in $(ENVS); do \
-		$(figlet_docker) "envs/$$env"; \
 		$(MAKE) -C terraform/envs/$$env fmt || exit $$?; \
 	done
 
 fmt-global:
-	$(figlet_docker) "global";
 	$(MAKE) -C terraform/global fmt || exit $$?
 
 fmt-modules:
 	@for module in $(MODULES); do \
-		$(figlet_docker) "modules/$$module"; \
 		$(MAKE) -C terraform/modules/$$module fmt || exit $$?; \
 	done
 


### PR DESCRIPTION
The extra 'echo' meant that the error code would not bubble up.

Also removed a bunch of figlet calls because for faster targets like fmt and lint they cause
a significant slowdown.