### PR TITLE
[feature] Don't run tf as root inside the docker container

### DIFF
--- a/templates/account/Makefile.tmpl
+++ b/templates/account/Makefile.tmpl
@@ -11,6 +11,7 @@ TF=$(wildcard *.tf)
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
+	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}

--- a/templates/component/Makefile.tmpl
+++ b/templates/component/Makefile.tmpl
@@ -11,6 +11,7 @@ TF=$(wildcard *.tf)
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
+	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}

--- a/templates/global/Makefile.tmpl
+++ b/templates/global/Makefile.tmpl
@@ -11,6 +11,7 @@ TF=$(wildcard *.tf)
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
+	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}

--- a/templates/module/Makefile.tmpl
+++ b/templates/module/Makefile.tmpl
@@ -11,6 +11,7 @@ TF=$(wildcard *.tf)
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
+	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}


### PR DESCRIPTION
Salient issue is that certain files (such as the plugin cache directory) are owned by root in the host filesystem. 

This PR is intended to work alongside https://github.com/chanzuckerberg/images/pull/21/files

Largely based off https://github.com/broadinstitute/viral-ngs-deploy/tree/951a1f3b68c7901d6a9a835ddaf5eb6c99a20612/docker