### PR TITLE
[breaking] Version docker image

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type defaults struct {
 	Owner              string            `json:"owner" validate:"required"`
 	Project            string            `json:"project" validate:"required"`
 	TerraformVersion   string            `json:"terraform_version" validate:"required"`
+	DockerImageVersion string            `json:"docker_image_version" validate:"required"`
 }
 
 type Account struct {
@@ -42,6 +43,7 @@ type Account struct {
 	Owner              *string           `json:"owner"`
 	Project            *string           `json:"project"`
 	TerraformVersion   *string           `json:"terraform_version"`
+	DockerImageVersion *string           `json:"docker_image_version"`
 }
 
 type Env struct {
@@ -52,6 +54,7 @@ type Env struct {
 	AWSRegionBackend   *string           `json:"aws_region_backend"`
 	AWSRegionProvider  *string           `json:"aws_region_provider"`
 	AWSRegions         []string          `json:"aws_regions"`
+	DockerImageVersion *string           `json:"docker_image_version"`
 	ExtraVars          map[string]string `json:"extra_vars,omitempty"`
 	InfraBucket        *string           `json:"infra_s3_bucket"`
 	Owner              *string           `json:"owner"`
@@ -70,6 +73,7 @@ type Component struct {
 	AWSRegionBackend   *string           `json:"aws_region_backend"`
 	AWSRegionProvider  *string           `json:"aws_region_provider"`
 	AWSRegions         []string          `json:"aws_regions"`
+	DockerImageVersion *string           `json:"docker_image_version"`
 	ExtraVars          map[string]string `json:"extra_vars,omitempty"`
 	InfraBucket        *string           `json:"infra_s3_bucket"`
 	ModuleSource       *string           `json:"module_source"`
@@ -79,7 +83,8 @@ type Component struct {
 }
 
 type Module struct {
-	TerraformVersion *string `json:"terraform_version"`
+	DockerImageVersion *string `json:"docker_image_version"`
+	TerraformVersion   *string `json:"terraform_version"`
 }
 
 type Config struct {
@@ -120,6 +125,7 @@ func InitConfig(project, region, bucket, awsProfile, owner, awsProviderVersion s
 			Owner:              owner,
 			Project:            project,
 			TerraformVersion:   "0.11.7",
+			DockerImageVersion: "0.11.0",
 		},
 		Accounts: map[string]Account{},
 		Envs:     map[string]Env{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -95,7 +95,7 @@ func TestValidation(t *testing.T) {
 
 	err, ok := e.(validator.ValidationErrors)
 	assert.True(t, ok)
-	assert.Len(t, err, 9)
+	assert.Len(t, err, 10)
 }
 
 func TestExtraVarsValidation(t *testing.T) {
@@ -110,7 +110,8 @@ func TestExtraVarsValidation(t *testing.T) {
 			"infra_s3_bucket": "the-bucket",
 			"project": "test-project",
 			"owner": "test@test.com",
-			"terraform_version": "0.11.0"
+			"terraform_version": "0.11.0",
+			"docker_image_version": "0.11.0"
 		}
 	}`
 	r := ioutil.NopCloser(strings.NewReader(json))
@@ -138,4 +139,5 @@ func TestInitConfig(t *testing.T) {
 	assert.Equal(t, "me@foo.example", c.Defaults.Owner)
 	assert.Equal(t, "proj", c.Defaults.Project)
 	assert.Equal(t, "0.11.7", c.Defaults.TerraformVersion)
+	assert.Equal(t, "0.11.0", c.Defaults.DockerImageVersion)
 }

--- a/plan/fixtures/full.json
+++ b/plan/fixtures/full.json
@@ -5,6 +5,7 @@
     "infra_s3_bucket": "buck",
     "project": "proj",
     "terraform_version": "0.100.0",
+    "docker_image_version": "1.100.0",
     "owner": "foo@example.com",
     "extra_vars": {
       "foo": "bar1"
@@ -28,7 +29,7 @@
       },
       "components": {
         "vpc": {
-					"module_source": "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0",
+          "module_source": "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0",
           "extra_vars": {
             "foo": "bar3"
           }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -22,37 +22,41 @@ type AWSConfiguration struct {
 
 type account struct {
 	AWSConfiguration
-	AllAccounts      map[string]int64
-	ExtraVars        map[string]string
-	Owner            string
-	Project          string
-	TerraformVersion string
+	AllAccounts        map[string]int64
+	DockerImageVersion string
+	ExtraVars          map[string]string
+	Owner              string
+	Project            string
+	TerraformVersion   string
 }
 
 type Module struct {
-	TerraformVersion string
+	DockerImageVersion string
+	TerraformVersion   string
 }
 
 type Component struct {
 	AWSConfiguration
-	Component        string
-	Env              string
-	ExtraVars        map[string]string
-	ModuleSource     *string
-	OtherComponents  []string
-	Owner            string
-	Project          string
-	TerraformVersion string
+	Component          string
+	DockerImageVersion string
+	Env                string
+	ExtraVars          map[string]string
+	ModuleSource       *string
+	OtherComponents    []string
+	Owner              string
+	Project            string
+	TerraformVersion   string
 }
 
 type Env struct {
 	AWSConfiguration
-	Components       map[string]Component
-	Env              string
-	ExtraVars        map[string]string
-	Owner            string
-	Project          string
-	TerraformVersion string
+	Components         map[string]Component
+	DockerImageVersion string
+	Env                string
+	ExtraVars          map[string]string
+	Owner              string
+	Project            string
+	TerraformVersion   string
 }
 
 type Plan struct {
@@ -118,6 +122,7 @@ func Print(p *Plan) error {
 		fmt.Printf("\t\towner: %v\n", account.Owner)
 		fmt.Printf("\t\tproject: %v\n", account.Project)
 		fmt.Printf("\t\tterraform_version: %v\n", account.TerraformVersion)
+		fmt.Printf("\t\tdocker_image_version: %v\n", account.DockerImageVersion)
 
 		fmt.Printf("\t\tall_accounts:\n")
 		for acct, id := range account.AllAccounts {
@@ -140,6 +145,7 @@ func Print(p *Plan) error {
 	fmt.Printf("\towner: %v\n", p.Global.Owner)
 	fmt.Printf("\tproject: %v\n", p.Global.Project)
 	fmt.Printf("\tterraform_version: %v\n", p.Global.TerraformVersion)
+	fmt.Printf("\tdocker_image_version: %v\n", p.Global.DockerImageVersion)
 
 	fmt.Println("Envs:")
 
@@ -159,6 +165,7 @@ func Print(p *Plan) error {
 		fmt.Printf("\t\towner: %v\n", env.Owner)
 		fmt.Printf("\t\tproject: %v\n", env.Project)
 		fmt.Printf("\t\tterraform_version: %v\n", env.TerraformVersion)
+		fmt.Printf("\t\tdocker_image_version: %v\n", env.DockerImageVersion)
 
 		fmt.Println("\t\tComponents:")
 
@@ -178,6 +185,7 @@ func Print(p *Plan) error {
 			fmt.Printf("\t\t\t\towner: %v\n", component.Owner)
 			fmt.Printf("\t\t\t\tproject: %v\n", component.Project)
 			fmt.Printf("\t\t\t\tterraform_version: %v\n", component.TerraformVersion)
+			fmt.Printf("\t\t\t\tdocker_image_version: %v\n", component.DockerImageVersion)
 		}
 
 	}
@@ -186,6 +194,7 @@ func Print(p *Plan) error {
 	for name, module := range p.Modules {
 		fmt.Printf("\t%s:\n", name)
 		fmt.Printf("\t\tterraform_version: %s\n", module.TerraformVersion)
+		fmt.Printf("\t\tdocker_image_version: %v\n", module.DockerImageVersion)
 	}
 	return nil
 }
@@ -209,6 +218,7 @@ func buildAccounts(c *config.Config) (map[string]account, error) {
 		accountPlan.AWSProviderVersion = resolveRequired(defaults.AWSProviderVersion, config.AWSProviderVersion)
 		accountPlan.AllAccounts = resolveAccounts(c.Accounts)
 		accountPlan.TerraformVersion = resolveRequired(defaults.TerraformVersion, config.TerraformVersion)
+		accountPlan.DockerImageVersion = resolveRequired(defaults.DockerImageVersion, config.DockerImageVersion)
 		accountPlan.InfraBucket = resolveRequired(defaults.InfraBucket, config.InfraBucket)
 		accountPlan.Owner = resolveRequired(defaults.Owner, config.Owner)
 		accountPlan.Project = resolveRequired(defaults.Project, config.Project)
@@ -226,6 +236,7 @@ func buildModules(c *config.Config) (map[string]Module, error) {
 		modulePlan := Module{}
 
 		modulePlan.TerraformVersion = resolveRequired(c.Defaults.TerraformVersion, conf.TerraformVersion)
+		modulePlan.DockerImageVersion = resolveRequired(c.Defaults.DockerImageVersion, conf.DockerImageVersion)
 		modulePlans[name] = modulePlan
 	}
 	return modulePlans, nil
@@ -254,6 +265,7 @@ func buildGlobal(conf *config.Config) (Component, error) {
 	// componentPlan.AccountID = conf.Defaults.AccountID
 
 	componentPlan.TerraformVersion = conf.Defaults.TerraformVersion
+	componentPlan.DockerImageVersion = conf.Defaults.DockerImageVersion
 	componentPlan.InfraBucket = conf.Defaults.InfraBucket
 	componentPlan.Owner = conf.Defaults.Owner
 	componentPlan.Project = conf.Defaults.Project
@@ -284,6 +296,7 @@ func buildEnvs(conf *config.Config) (map[string]Env, error) {
 		envPlan.AWSProviderVersion = resolveRequired(defaults.AWSProviderVersion, envConf.AWSProviderVersion)
 
 		envPlan.TerraformVersion = resolveRequired(defaults.TerraformVersion, envConf.TerraformVersion)
+		envPlan.DockerImageVersion = resolveRequired(defaults.DockerImageVersion, envConf.DockerImageVersion)
 		envPlan.InfraBucket = resolveRequired(defaults.InfraBucket, envConf.InfraBucket)
 		envPlan.Owner = resolveRequired(defaults.Owner, envConf.Owner)
 		envPlan.Project = resolveRequired(defaults.Project, envConf.Project)
@@ -303,6 +316,7 @@ func buildEnvs(conf *config.Config) (map[string]Env, error) {
 			componentPlan.AccountID = resolveOptionalInt(envPlan.AccountID, componentConf.AccountID)
 
 			componentPlan.TerraformVersion = resolveRequired(envPlan.TerraformVersion, componentConf.TerraformVersion)
+			componentPlan.DockerImageVersion = resolveRequired(envPlan.DockerImageVersion, componentConf.DockerImageVersion)
 			componentPlan.InfraBucket = resolveRequired(envPlan.InfraBucket, componentConf.InfraBucket)
 			componentPlan.Owner = resolveRequired(envPlan.Owner, componentConf.Owner)
 			componentPlan.Project = resolveRequired(envPlan.Project, componentConf.Project)

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -76,12 +76,14 @@ func TestPlanBasic(t *testing.T) {
 	assert.NotNil(t, plan.Modules)
 	assert.Len(t, plan.Modules, 1)
 	assert.Equal(t, "0.100.0", plan.Modules["my_module"].TerraformVersion)
+	assert.Equal(t, "1.100.0", plan.Modules["my_module"].DockerImageVersion)
 
 	assert.NotNil(t, plan.Envs)
 	assert.Len(t, plan.Envs, 2)
 
 	assert.NotNil(t, plan.Envs["staging"])
 	assert.Equal(t, plan.Envs["staging"].TerraformVersion, "0.100.0")
+	assert.Equal(t, plan.Envs["staging"].DockerImageVersion, "1.100.0")
 
 	assert.NotNil(t, plan.Envs["staging"].Components)
 	assert.Len(t, plan.Envs["staging"].Components, 3)
@@ -94,6 +96,7 @@ func TestPlanBasic(t *testing.T) {
 
 	assert.NotNil(t, plan.Envs["staging"].Components["comp1"])
 	assert.Equal(t, "0.100.0", plan.Envs["staging"].Components["comp1"].TerraformVersion)
+	assert.Equal(t, "1.100.0", plan.Envs["staging"].Components["comp1"].DockerImageVersion)
 }
 
 func TestExtraVarsComposition(t *testing.T) {

--- a/templates/account/Makefile.tmpl
+++ b/templates/account/Makefile.tmpl
@@ -7,6 +7,7 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)
+DOCKER_TAG={{ .DockerImageVersion }}_TF{{ .TerraformVersion }}
 
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
@@ -14,8 +15,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:$(DOCKER_TAG)
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:$(DOCKER_TAG)
 
 all:
 

--- a/templates/account/Makefile.tmpl
+++ b/templates/account/Makefile.tmpl
@@ -14,8 +14,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
 
 all:
 

--- a/templates/component/Makefile.tmpl
+++ b/templates/component/Makefile.tmpl
@@ -7,6 +7,7 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)
+DOCKER_TAG={{ .DockerImageVersion }}_TF{{ .TerraformVersion }}
 
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
@@ -14,8 +15,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:$(DOCKER_TAG)
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:$(DOCKER_TAG)
 
 all:
 

--- a/templates/component/Makefile.tmpl
+++ b/templates/component/Makefile.tmpl
@@ -14,8 +14,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
 
 all:
 

--- a/templates/global/Makefile.tmpl
+++ b/templates/global/Makefile.tmpl
@@ -7,6 +7,7 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)
+DOCKER_TAG={{ .DockerImageVersion }}_TF{{ .TerraformVersion }}
 
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
@@ -14,8 +15,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:$(DOCKER_TAG)
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:$(DOCKER_TAG)
 
 all:
 

--- a/templates/global/Makefile.tmpl
+++ b/templates/global/Makefile.tmpl
@@ -14,8 +14,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
 
 all:
 

--- a/templates/module/Makefile.tmpl
+++ b/templates/module/Makefile.tmpl
@@ -14,8 +14,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
 
 all: fmt lint doc
 

--- a/templates/module/Makefile.tmpl
+++ b/templates/module/Makefile.tmpl
@@ -7,6 +7,7 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)
+DOCKER_TAG={{ .DockerImageVersion }}_TF{{ .TerraformVersion }}
 
 docker_base = \
 	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
@@ -14,8 +15,8 @@ docker_base = \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
 	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
-docker_terraform = $(docker_base) chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
-docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:{{ .TerraformVersion }}_{{ .DockerImageVersion }}
+docker_terraform = $(docker_base) chanzuckerberg/terraform:$(DOCKER_TAG)
+docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:$(DOCKER_TAG)
 
 all: fmt lint doc
 


### PR DESCRIPTION
Added a new field to the config `docker_image_version` to start versioning the chanzuckerberg/terraform docker image. 
Works with https://github.com/chanzuckerberg/images/pull/25