### PR TITLE
Remove TTY from all but fogg apply (closes #127)

### DIFF
--- a/templates/env/Makefile.tmpl
+++ b/templates/env/Makefile.tmpl
@@ -2,7 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 COMPONENTS={{ .Components | dict | keys | sortAlpha | join " "}}
-figlet_docker = docker run -it --rm mbentley/figlet
+figlet_docker = docker run --rm mbentley/figlet
 
 all:
 

--- a/templates/module/Makefile.tmpl
+++ b/templates/module/Makefile.tmpl
@@ -10,7 +10,7 @@ TF=$(wildcard *.tf)
 IMAGE_VERSION={{ .DockerImageVersion }}_TF{{ .TerraformVersion }}
 
 docker_base = \
-	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
+	docker run --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-v $(REPO_ROOT)/.bin:/usr/local/bin -v $(REPO_ROOT)/terraform.d:/repo/$(REPO_RELATIVE_PATH)/terraform.d \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \

--- a/templates/repo/Makefile.tmpl
+++ b/templates/repo/Makefile.tmpl
@@ -5,7 +5,7 @@ ENVS={{ .Envs | dict | keys | sortAlpha | join " "}}
 MODULES={{ .Modules | dict | keys | sortAlpha | join " "}}
 ACCOUNTS={{ .Accounts | dict | keys | sortAlpha | join " "}}
 
-figlet_docker = docker run -it --rm mbentley/figlet
+figlet_docker = docker run --rm mbentley/figlet
 
 all: check
 

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -46,10 +46,8 @@ get: ssh-forward
 plan: fmt get init ssh-forward
 	$(docker_terraform) plan
 
-apply: fmt get init ssh-forward real-apply
-
-real-apply: FOGG_DOCKER_FLAGS = -it
-real-apply:
+apply: FOGG_DOCKER_FLAGS = -it
+apply: fmt get init ssh-forward
 	$(docker_terraform) apply -auto-approve=false
 
 docs:

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -10,12 +10,12 @@ TF=$(wildcard *.tf)
 IMAGE_VERSION=$(DOCKER_IMAGE_VERSION)_TF$(TERRAFORM_VERSION)
 
 docker_base = \
-	docker run -it --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
+	docker run --rm -e HOME=/home -v $$HOME/.aws:/home/.aws -v $(REPO_ROOT):/repo \
 	-v $(REPO_ROOT)/.bin:/usr/local/bin -v $(REPO_ROOT)/terraform.d:/repo/$(REPO_RELATIVE_PATH)/terraform.d \
 	-e GIT_SSH_COMMAND='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
 	-e RUN_USER_ID=$(shell id -u) -e RUN_GROUP_ID=$(shell id -g) \
 	-e TF_PLUGIN_CACHE_DIR="/repo/.terraform.d/plugin-cache" -e TF="$(TF)" \
-	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
+	-w /repo/$(REPO_RELATIVE_PATH) $(TF_VARS) $(FOGG_DOCKER_FLAGS) $$(sh $(REPO_ROOT)/scripts/docker-ssh-mount.sh)
 docker_terraform = $(docker_base) chanzuckerberg/terraform:$(IMAGE_VERSION)
 docker_sh = $(docker_base) --entrypoint='/bin/sh' chanzuckerberg/terraform:$(IMAGE_VERSION)
 
@@ -46,7 +46,10 @@ get: ssh-forward
 plan: fmt get init ssh-forward
 	$(docker_terraform) plan
 
-apply: fmt get init ssh-forward
+apply: fmt get init ssh-forward real-apply
+
+real-apply: FOGG_DOCKER_FLAGS = -it
+real-apply:
 	$(docker_terraform) apply -auto-approve=false
 
 docs:


### PR DESCRIPTION
This PR removes all the `-it` flags from all docker calls except make apply, effectively removing the TTY allocation.

For the fogg apply, we create a new variable `FOGG_DOCKER_FLAGS` that defaults to blank except in the apply command. We separate apply into apply and real-apply, so that the `-it` flags only apply to the actual `terraform apply` command and not the fmt/get/init/ssh-forward targets, using make's support of [https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html](target-specific flags)