### PR TITLE
[feature] check for version mis-match on apply

### DIFF
--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -297,7 +297,7 @@ func TestCheckToolVersions(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			writeFile(fs, ".fogg-version", tc.current)
 
-			v, e := checkToolVersions(fs, tc.tool)
+			v, _, e := checkToolVersions(fs, tc.tool)
 			a.NoError(e)
 			a.Equal(tc.result, v)
 		})

--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -158,7 +158,7 @@ func TestApplySmokeTest(t *testing.T) {
 	c, e := config.ReadConfig(ioutil.NopCloser(strings.NewReader(json)))
 	assert.Nil(t, e)
 
-	e = Apply(fs, c, templates.Templates)
+	e = Apply(fs, c, templates.Templates, false)
 	assert.Nil(t, e)
 }
 
@@ -270,6 +270,48 @@ func TestCalculateLocalPath(t *testing.T) {
 			p, e := calculateModuleAddressForSource(test.path, test.moduleAddress)
 			assert.Nil(t, e)
 			assert.Equal(t, test.expected, p)
+		})
+	}
+}
+
+var versionTests = []struct {
+	current string
+	tool    string
+	result  bool
+}{
+	{"0.0.0", "0.1.0", true},
+	{"0.1.0", "0.0.0", true},
+	{"0.1.0", "0.1.0", false},
+	{"0.1.0", "0.1.0-abcdef", true},
+	{"0.1.0", "0.1.0-abcdef-dirty", true},
+	{"0.1.0-abcdef-dirty", "0.1.0", true},
+	{"0.1.0-abc", "0.1.0-def", true},
+	{"0.1.0-abc", "0.1.0-abc", false},
+}
+
+func TestCheckToolVersions(t *testing.T) {
+	a := assert.New(t)
+
+	for _, tc := range versionTests {
+		t.Run("", func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			writeFile(fs, ".fogg-version", tc.current)
+
+			v, e := checkToolVersions(fs, tc.tool)
+			a.NoError(e)
+			a.Equal(tc.result, v)
+		})
+	}
+}
+
+func TestVersionIsChanged(t *testing.T) {
+	a := assert.New(t)
+
+	for _, test := range versionTests {
+		t.Run("", func(t *testing.T) {
+			b, e := versionIsChanged(test.current, test.tool)
+			a.NoError(e)
+			a.Equal(test.result, b)
 		})
 	}
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	applyCmd.Flags().StringP("config", "c", "fogg.json", "Use this to override the fogg config file.")
 	applyCmd.Flags().BoolP("verbose", "v", false, "use this to turn on verbose output")
+	applyCmd.Flags().BoolP("upgrade", "u", false, "use this when running a new version of fogg")
 	rootCmd.AddCommand(applyCmd)
 }
 
@@ -47,6 +48,11 @@ var applyCmd = &cobra.Command{
 			log.Panic(e)
 		}
 
+		upgrade, e := cmd.Flags().GetBool("upgrade")
+		if e != nil {
+			log.Panic(e)
+		}
+
 		// check that we are at root of initialized git repo
 		openGitOrExit(pwd)
 
@@ -55,7 +61,7 @@ var applyCmd = &cobra.Command{
 		exitOnConfigErrors(err)
 
 		// apply
-		e = apply.Apply(fs, config, templates.Templates)
+		e = apply.Apply(fs, config, templates.Templates, upgrade)
 		if e != nil {
 			log.Panic(e)
 		}

--- a/util/version.go
+++ b/util/version.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -37,6 +38,24 @@ func VersionCacheKey() string {
 		return ""
 	}
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+func ParseVersion(version string) (semver.Version, string, bool) {
+	var dirty bool
+	var sha string
+	v := version
+	if strings.HasSuffix(v, "-dirty") {
+		dirty = true
+		v = strings.TrimSuffix(v, "-dirty")
+	}
+	if strings.Contains(v, "-") {
+		tmp := strings.Split(v, "-")
+		v = tmp[0]
+		sha = tmp[1]
+	}
+
+	semVersion, _ := semver.Parse(v)
+	return semVersion, sha, dirty
 }
 
 func versionString(version, sha string, release, dirty bool) string {

--- a/util/version_test.go
+++ b/util/version_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,5 +16,31 @@ func TestVersionString(t *testing.T) {
 
 	s = versionString("0.1.0", "abcdef", false, true)
 	assert.Equal(t, "0.1.0-abcdef-dirty", s)
+
+}
+
+func TestParse(t *testing.T) {
+	a := assert.New(t)
+
+	testCases := []struct {
+		input   string
+		version string
+		sha     string
+		dirty   bool
+	}{
+		{"0.1.0", "0.1.0", "", false},
+		{"0.1.0-abcdef", "0.1.0", "abcdef", false},
+		{"0.1.0-abcdef-dirty", "0.1.0", "abcdef", true},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			v, sha, dirty := ParseVersion(tc.input)
+			semVersion, e := semver.Parse(tc.version)
+			a.NoError(e)
+			a.Equal(semVersion, v)
+			a.Equal(tc.sha, sha)
+			a.Equal(tc.dirty, dirty)
+		})
+	}
 
 }


### PR DESCRIPTION

This will check to see if the version in .fogg-version matches the current tool version. If --upgrade/-u is not supplied, apply will fail.

Currently the UX for this error is bad. After the PR I will do a pass at better error UX before we do a release.

Fixes #51 
