### PR TITLE
Add fogg apply/plan --no-plugins flag

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -28,7 +28,7 @@ import (
 const rootPath = "terraform"
 
 // Apply will run a plan and apply all the changes to the current repo.
-func Apply(fs afero.Fs, conf *config.Config, tmp *templates.T, upgrade bool) error {
+func Apply(fs afero.Fs, conf *config.Config, tmp *templates.T, upgrade bool, noPlugins bool) error {
 	if !upgrade {
 		toolVersion, err := util.VersionString()
 		if err != nil {
@@ -39,7 +39,7 @@ func Apply(fs afero.Fs, conf *config.Config, tmp *templates.T, upgrade bool) err
 			return errs.NewUserf("fogg version (%s) is different than version currently used to manage repo (%s). To upgrade add --upgrade.", toolVersion, repoVersion)
 		}
 	}
-	p, err := plan.Eval(conf, false)
+	p, err := plan.Eval(conf, false, noPlugins)
 	if err != nil {
 		return errs.WrapUser(err, "unable to evaluate plan")
 	}

--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -158,7 +158,7 @@ func TestApplySmokeTest(t *testing.T) {
 	c, e := config.ReadConfig(ioutil.NopCloser(strings.NewReader(json)))
 	assert.Nil(t, e)
 
-	e = Apply(fs, c, templates.Templates, false)
+	e = Apply(fs, c, templates.Templates, false, false)
 	assert.Nil(t, e)
 }
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -14,6 +14,7 @@ func init() {
 	applyCmd.Flags().StringP("config", "c", "fogg.json", "Use this to override the fogg config file.")
 	applyCmd.Flags().BoolP("verbose", "v", false, "use this to turn on verbose output")
 	applyCmd.Flags().BoolP("upgrade", "u", false, "use this when running a new version of fogg")
+	applyCmd.Flags().Bool("no-plugins", false, "do not apply fogg plugins; this may result in unexpected behavior.")
 	rootCmd.AddCommand(applyCmd)
 }
 
@@ -54,6 +55,11 @@ var applyCmd = &cobra.Command{
 			return e
 		}
 
+		noPlugins, e := cmd.Flags().GetBool("no-plugins")
+		if e != nil {
+			return e
+		}
+
 		// check that we are at root of initialized git repo
 		openGitOrExit(pwd)
 
@@ -65,7 +71,7 @@ var applyCmd = &cobra.Command{
 		}
 
 		// apply
-		e = apply.Apply(fs, config, templates.Templates, upgrade)
+		e = apply.Apply(fs, config, templates.Templates, upgrade, noPlugins)
 
 		return e
 	},

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	planCmd.Flags().StringP("config", "c", "fogg.json", "Use this to override the fogg config file.")
 	planCmd.Flags().BoolP("verbose", "v", false, "use this to turn on verbose output")
+	planCmd.Flags().Bool("no-plugins", false, "do not apply fogg plugins; this may result in unexpected behavior.")
 	rootCmd.AddCommand(planCmd)
 }
 
@@ -49,6 +50,11 @@ var planCmd = &cobra.Command{
 			return errs.WrapInternal(e, "couldn't parse config flag")
 		}
 
+		noPlugins, e := cmd.Flags().GetBool("no-plugins")
+		if e != nil {
+			return e
+		}
+
 		// check that we are at root of initialized git repo
 		openGitOrExit(pwd)
 
@@ -59,7 +65,7 @@ var planCmd = &cobra.Command{
 			return e
 		}
 
-		p, e := plan.Eval(config, verbose)
+		p, e := plan.Eval(config, verbose, noPlugins)
 		if e != nil {
 			return e
 		}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -119,15 +119,17 @@ type Plan struct {
 }
 
 // Eval evaluats a config
-func Eval(config *config.Config, verbose bool) (*Plan, error) {
+func Eval(config *config.Config, verbose bool, noPlugins bool) (*Plan, error) {
 	p := &Plan{}
 	v, e := util.VersionString()
 	if e != nil {
 		return nil, errs.WrapInternal(e, "unable to parse fogg version")
 	}
 	p.Version = v
-	p.Plugins.SetCustomPluginsPlan(config.Plugins.CustomPlugins)
-	p.Plugins.SetTerraformProvidersPlan(config.Plugins.TerraformProviders)
+	if !noPlugins {
+		p.Plugins.SetCustomPluginsPlan(config.Plugins.CustomPlugins)
+		p.Plugins.SetTerraformProvidersPlan(config.Plugins.TerraformProviders)
+	}
 
 	var err error
 	p.Accounts = p.buildAccounts(config)

--- a/plan/testdata/full.json
+++ b/plan/testdata/full.json
@@ -28,7 +28,7 @@
       },
       "components": {
         "vpc": {
-					"module_source": "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0",
+          "module_source": "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0",
           "extra_vars": {
             "foo": "bar3"
           }
@@ -38,5 +38,19 @@
       }
     },
     "prod": {}
+  },
+  "plugins": {
+    "terraform_providers": {
+      "provider": {
+        "url": "https://example.com/provider.tar.gz",
+        "format": "tar"
+      }
+    },
+    "custom_plugins": {
+      "custom": {
+        "url": "https://example.com/custom.zip",
+        "format": "zip"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR scratches an itch about running fogg while offline or on a slow/expensive connection (e.g. from Caltrain)

It adds a flag to fogg plan and fogg apply, --no-plugins, which skips installing plugins. It's potentially a dangerous command, and it warns you there is danger, if you run terraform apply without having the most recent plugins installed, resulting in either commands failing, or in the worst case wrong behavior if a previously installed plugin had different behavior than the updated version. However, if you know for sure that your plugins are up to date, the flag provides an escape hatch to avoid the slow/expensive download that may not even be possible without Internet access.

It may not be the best way (a better way may be tracking a plugin cache), but wanted to at least start a discussion.