### PR TITLE
Restore tty to make run

### DIFF
--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -77,6 +77,7 @@ check-plan: init get ssh-forward
 ssh-forward:
 	bash $(REPO_ROOT)/scripts/docker-ssh-forward.sh
 
+run: FOGG_DOCKER_FLAGS = -it
 run:
 	$(docker_terraform) $(CMD)
 


### PR DESCRIPTION
I realize I often use fogg run in an interactive mode (e.g. when doing `make run CMD="destroy"`), and the recent change from #127 removed that. This PR restores the TTY to make run. If we have future use cases where we need it disabled, we can see about expanding the Makefile at that point.