### PR TITLE
fix build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,8 @@
+before:
+  hooks:
+    - make clean
+    - make packr
+
 builds:
   - binary: fogg
     env:

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,13 @@ lint-slow: ## run all linters, even the slow ones
 
 packr: ## run the packr tool to generate our static files
 	packr clean -v
-	packr build -v
+	packr -v
 
-release: clean packr
+release: ## run a release
 	goreleaser release --rm-dist
+
+release-snapshot: ## run a release
+	goreleaser release --rm-dist --snapshot
 
 build: packr ## build the binary
 	go build ${LDFLAGS} .


### PR DESCRIPTION
Not sure how, but our packr implemenation stopped working at 0.15.0, which mean users getting errors like
`ERROR: unable to apply repo: lstat /Users/rking: no such file or directory`.

The templates were not properly getting packr'ed and this fixes that problem.