### PR TITLE
fix .travis.yml when id account is also an account

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,6 @@ type Module struct {
 type TravisCI struct {
 	Enabled        bool   `json:"enabled"`
 	AWSIAMRoleName string `json:"aws_iam_role_name"`
-	IDAccountName  string `json:"id_account_name"`
 	TestBuckets    int    `json:"test_buckets"`
 }
 

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -87,10 +87,9 @@ type TfLint struct {
 }
 
 type AWSProfile struct {
-	Name          string
-	ID            int64
-	Role          string
-	IDAccountName string
+	Name string
+	ID   int64
+	Role string
 }
 
 // Plugins contains a plan around plugins

--- a/plan/travisci.go
+++ b/plan/travisci.go
@@ -8,10 +8,9 @@ import (
 )
 
 type TravisCI struct {
-	Enabled          bool
-	AWSIDAccountName string
-	AWSProfiles      []AWSProfile
-	TestBuckets      [][]string
+	Enabled     bool
+	AWSProfiles []AWSProfile
+	TestBuckets [][]string
 }
 
 func (p *Plan) buildTravisCI(c *config.Config) TravisCI {
@@ -20,8 +19,7 @@ func (p *Plan) buildTravisCI(c *config.Config) TravisCI {
 	}
 
 	tr := TravisCI{
-		Enabled:          c.TravisCI.Enabled,
-		AWSIDAccountName: c.TravisCI.IDAccountName,
+		Enabled: c.TravisCI.Enabled,
 	}
 	var profiles []AWSProfile
 
@@ -30,9 +28,8 @@ func (p *Plan) buildTravisCI(c *config.Config) TravisCI {
 			Name: name,
 			// TODO since accountID is required here, that means we need
 			// to make it non-optional, either in defaults or post-plan.
-			ID:            *p.Accounts[name].AccountID,
-			Role:          c.TravisCI.AWSIAMRoleName,
-			IDAccountName: c.TravisCI.IDAccountName,
+			ID:   *p.Accounts[name].AccountID,
+			Role: c.TravisCI.AWSIAMRoleName,
 		})
 	}
 	tr.AWSProfiles = profiles

--- a/plan/travisci_test.go
+++ b/plan/travisci_test.go
@@ -41,7 +41,6 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 		TravisCI: &config.TravisCI{
 			Enabled:        true,
 			AWSIAMRoleName: "rollin",
-			IDAccountName:  "hub",
 		},
 	}
 	p := &Plan{}
@@ -51,7 +50,6 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 	a.Equal(tr.AWSProfiles[0].Name, "foo")
 	a.Equal(tr.AWSProfiles[0].ID, id1)
 	a.Equal(tr.AWSProfiles[0].Role, "rollin")
-	a.Equal(tr.AWSProfiles[0].IDAccountName, "hub")
 }
 
 func Test_buildTravisCI_TestBuckets(t *testing.T) {
@@ -69,7 +67,6 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 		TravisCI: &config.TravisCI{
 			Enabled:        true,
 			AWSIAMRoleName: "rollin",
-			IDAccountName:  "hub",
 		},
 	}
 

--- a/templates/travis-ci/.travis.yml.tmpl
+++ b/templates/travis-ci/.travis.yml.tmpl
@@ -9,13 +9,13 @@ install:
   - aws --version
 before_script:
   # TODO add note about why these need to be prefixed with HUB_
-  - aws configure set aws_access_key_id     $IDACCT_AWS_ACCESS_KEY_ID     --profile {{ .AWSIDAccountName }}
-  - aws configure set aws_secret_access_key $IDACCT_AWS_SECRET_ACCESS_KEY --profile {{ .AWSIDAccountName }}
-  - aws --profile {{ .AWSIDAccountName }} sts get-caller-identity
+  - aws configure set aws_access_key_id     $IDACCT_AWS_ACCESS_KEY_ID     --profile _idacct
+  - aws configure set aws_secret_access_key $IDACCT_AWS_SECRET_ACCESS_KEY --profile _idacct
+  - aws --profile _idacct sts get-caller-identity
 
 {{ range $profile := .AWSProfiles}}
   - aws configure set profile.{{ $profile.Name }}.role_arn arn:aws:iam::{{ $profile.ID }}:role/{{ $profile.Role}}
-  - aws configure set profile.{{ $profile.Name }}.source_profile {{ $profile.IDAccountName }}
+  - aws configure set profile.{{ $profile.Name }}.source_profile _idacct
   - aws --profile {{ $profile.Name }} sts get-caller-identity
 {{ end }}
 


### PR DESCRIPTION
This fixes a problem with the new .travis.yml generation – if the account with the ids (IAM Users) is also an account you are managing, you get duplicate profiles.