### PR TITLE
Ensure directories are created before template/touch

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -273,7 +273,14 @@ func fmtHcl(fs afero.Fs, path string) error {
 }
 
 func touchFile(dest afero.Fs, path string) error {
-	_, err := dest.Stat(path)
+	dir, _ := filepath.Split(path)
+	ospath := filepath.FromSlash(dir)
+	err := dest.MkdirAll(ospath, 0755)
+	if err != nil {
+		return errs.WrapUserf(err, "couldn't create %s directory", dir)
+	}
+
+	_, err = dest.Stat(path)
 	if err != nil { // TODO we might not want to do this for all errors
 		log.Infof("%s touched", path)
 		_, err = dest.Create(path)
@@ -305,6 +312,13 @@ func removeExtension(path string) string {
 }
 
 func applyTemplate(sourceFile io.Reader, dest afero.Fs, path string, overrides interface{}) error {
+	dir, _ := filepath.Split(path)
+	ospath := filepath.FromSlash(dir)
+	err := dest.MkdirAll(ospath, 0755)
+	if err != nil {
+		return errs.WrapUserf(err, "couldn't create %s directory", dir)
+	}
+
 	log.Infof("%s templated", path)
 	writer, err := dest.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {

--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"math/rand"
+	"path/filepath"
 
 	"github.com/chanzuckerberg/fogg/config"
 	"github.com/chanzuckerberg/fogg/templates"
@@ -20,6 +22,26 @@ func init() {
 	}
 	log.SetFormatter(formatter)
 }
+
+func randomString(n int) string {
+    var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+    b := make([]rune, n)
+    for i := range b {
+        b[i] = letter[rand.Intn(len(letter))]
+    }
+    return string(b)
+}
+
+func getNonExistentDirectoryName() string {
+	nonexistentDir := "noexist-" + randomString(20)
+	for {
+		_, err := os.Stat(nonexistentDir)
+		if os.IsNotExist(err) { return nonexistentDir; }
+		nonexistentDir = "noexist-" + randomString(20)
+	}
+}
+
 func TestRemoveExtension(t *testing.T) {
 	x := removeExtension("foo")
 	assert.Equal(t, "foo", x)
@@ -43,6 +65,24 @@ func TestApplyTemplateBasic(t *testing.T) {
 	e := applyTemplate(sourceFile, dest, path, overrides)
 	assert.Nil(t, e)
 	f, e := dest.Open("bar")
+	assert.Nil(t, e)
+	r, e := ioutil.ReadAll(f)
+	assert.Nil(t, e)
+	assert.Equal(t, "foo", string(r))
+}
+
+func TestApplyTemplateBasicNewDirectory(t *testing.T) {
+	sourceFile := strings.NewReader("foo")
+	// Potential errors do not show up if using NewMemMapFs; needs real OS fs.
+	dest := afero.NewOsFs()
+	nonexistentDir := getNonExistentDirectoryName()
+	defer dest.RemoveAll(nonexistentDir)
+	path := filepath.Join(nonexistentDir, "bar")
+	overrides := struct{ Foo string }{"foo"}
+
+	e := applyTemplate(sourceFile, dest, path, overrides)
+	assert.Nil(t, e)
+	f, e := dest.Open(path)
 	assert.Nil(t, e)
 	r, e := ioutil.ReadAll(f)
 	assert.Nil(t, e)
@@ -89,6 +129,19 @@ func TestTouchFile(t *testing.T) {
 
 }
 
+func TestTouchFileNonExistentDirectory(t *testing.T) {
+	// Potential errors do not show up if using NewMemMapFs; needs real OS fs.
+	dest := afero.NewOsFs()
+	nonexistentDir := getNonExistentDirectoryName()
+	defer dest.RemoveAll(nonexistentDir)
+	e := touchFile(dest, filepath.Join(nonexistentDir, "foo"))
+	assert.Nil(t, e)
+	r, e := readFile(dest, filepath.Join(nonexistentDir, "foo"))
+	assert.Nil(t, e)
+	assert.Equal(t, "", r)
+	assert.Nil(t, e)
+}
+
 func TestCreateFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
@@ -116,6 +169,19 @@ func TestCreateFile(t *testing.T) {
 	assert.Nil(t, e)
 
 	r, e = readFile(fs, "foo")
+	assert.Nil(t, e)
+	assert.Equal(t, "bar", r)
+}
+
+func TestCreateFileNonExistentDirectory(t *testing.T) {
+
+	// create new file in nonexistent directory
+	dest := afero.NewOsFs()
+
+	e := createFile(dest, "newdir/foo", strings.NewReader("bar"))
+	assert.Nil(t, e)
+
+	r, e := readFile(dest, "newdir/foo")
 	assert.Nil(t, e)
 	assert.Equal(t, "bar", r)
 


### PR DESCRIPTION
This PR fixes a rare case that happens when initializing a new fogg repo, where an error occurs if a directory does not yet exist when a file is templated. This only happens when the source.Walk inside applyTree happens to pick an order where the first file for the directory happens to be a templated or touched file, before any created or copied files. (From what I can tell, source.Walk walks the files in a random order that changes on each run).

Below is an example of back to back runs on my local machine in an empty directory (except for fogg.json and .git), the first where the error occurs, the 2nd a subsequent run with no filesystem changes in between. Note that the scripts directory does not exist at the start of this.
```
$ fogg apply
INFO scripts/ssh_config templated
ERROR: unable to apply repo: unable to apply template: unable to open file: open /Users/mbarrientos/work/foobar/scripts/ssh_config: no such file or directory
$ fogg apply
INFO Makefile templated
INFO scripts/bless_ssh_config removed
INFO scripts/docker-ssh-forward.sh copied
INFO scripts/docker-ssh-mount.sh copied
INFO scripts/update-readme.sh copied
INFO .fogg-version templated
INFO scripts/dependencies.mk templated
...
```
If a .create or a normal copied file happens to be first, the afero.WriteReader will create the directory, and subsequent templates/touches won't run into the error. If a user reruns fogg immediately, and it happens to pick a different order where a copy/create occurs first, the error won't occur. Obviously, once the directory has already been created, the error won't occur for subsequent runs.

This PR adds a MkdirAll to the beginning of touchFile and templateFile. We continue to rely on the behavior afero.WriteReader for .create and copied files, and intentionally do not create the directory on .rm files.

Unit testing using NewMemMapFs does not exhibit the behavior; it requires NewOsFs backed with a real filesystem. The unit tests do this with a randomly created directory that is cleaned up at the end of the test run.