### PR TITLE
pre-releases

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -21,12 +21,4 @@ archive:
   - none*
 
 release:
-  prerelease: false
-
-brew:
-  description: "Terraform without pain."
-  github:
-    owner: chanzuckerberg
-    name: homebrew-tap
-  homepage: "https://github.com/chanzuckerberg/fogg"
-  test: system "#{bin}/fogg version"
+  prerelease: true

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,17 @@ packr: ## run the packr tool to generate our static files
 release: ## run a release
 	./bin/bff bump
 	git push
-	goreleaser release --rm-dist
+	goreleaser release
+
+release-prerelease: build ## release to github as a 'pre-release'
+	version=`./fogg version`; \
+	git tag v"$$version"; \
+	git push
+	git push --tags
+	goreleaser release -f .goreleaser.prerelease.yml --debug
 
 release-snapshot: ## run a release
-	goreleaser release --rm-dist --snapshot
+	goreleaser release --snapshot
 
 build: packr ## build the binary
 	go build ${LDFLAGS} .

--- a/util/version.go
+++ b/util/version.go
@@ -44,12 +44,12 @@ func ParseVersion(version string) (semver.Version, string, bool) {
 	var dirty bool
 	var sha string
 	v := version
-	if strings.HasSuffix(v, "-dirty") {
+	if strings.HasSuffix(v, ".dirty") {
 		dirty = true
-		v = strings.TrimSuffix(v, "-dirty")
+		v = strings.TrimSuffix(v, ".dirty")
 	}
-	if strings.Contains(v, "+") {
-		tmp := strings.Split(v, "+")
+	if strings.Contains(v, "-") {
+		tmp := strings.Split(v, "-")
 		v = tmp[0]
 		sha = tmp[1]
 	}
@@ -63,7 +63,7 @@ func versionString(version, sha string, release, dirty bool) string {
 		return version
 	}
 	if !dirty {
-		return fmt.Sprintf("%s+%s", version, sha)
+		return fmt.Sprintf("%s-%s", version, sha)
 	}
-	return fmt.Sprintf("%s+%s-dirty", version, sha)
+	return fmt.Sprintf("%s-%s.dirty", version, sha)
 }

--- a/util/version_test.go
+++ b/util/version_test.go
@@ -12,11 +12,10 @@ func TestVersionString(t *testing.T) {
 	assert.Equal(t, "0.1.0", s)
 
 	s = versionString("0.1.0", "abcdef", false, false)
-	assert.Equal(t, "0.1.0+abcdef", s)
+	assert.Equal(t, "0.1.0-abcdef", s)
 
 	s = versionString("0.1.0", "abcdef", false, true)
-	assert.Equal(t, "0.1.0+abcdef-dirty", s)
-
+	assert.Equal(t, "0.1.0-abcdef.dirty", s)
 }
 
 func TestParse(t *testing.T) {
@@ -29,8 +28,8 @@ func TestParse(t *testing.T) {
 		dirty   bool
 	}{
 		{"0.1.0", "0.1.0", "", false},
-		{"0.1.0+abcdef", "0.1.0", "abcdef", false},
-		{"0.1.0+abcdef-dirty", "0.1.0", "abcdef", true},
+		{"0.1.0-abcdef", "0.1.0", "abcdef", false},
+		{"0.1.0-abcdef.dirty", "0.1.0", "abcdef", true},
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
This will allow us to publish to github as a 'pre-release'. Will also skip homebrew.

This is useful for testing changes where you need the new fogg binary in CI.

This also changes the version format for non-release versions to better conform to the semver standard.