### PR TITLE
ignore snyk when var not set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,4 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     - stage: check
       script:
-        - snyk monitor --org=czi
-        - snyk test
-      if: NOT env(SNYK_TOKEN) IS present
+        - if [[ -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ jobs:
       script:
         - snyk monitor --org=czi
         - snyk test
-      if: env(SNYK_TOKEN) IS present
+      if: NOT env(SNYK_TOKEN) IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     - stage: check
       script:
-        - if [[ -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi
+        - if [[ ! -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi


### PR DESCRIPTION
It appears the previous approach doesn't work. I speculate that they don't consider that encrypted env variables are ignored for forks. 🤷‍♂️ 