### PR TITLE
ignore vim swap files in .gitignore

### DIFF
--- a/templates/repo/.gitignore
+++ b/templates/repo/.gitignore
@@ -13,6 +13,14 @@
 # Pycharm folder
 .idea
 
+# Editor Swap Files
+*.swp
+*.swo
+*.swn
+*.swm
+*.swl
+*.swk
+
 .fogg
 /terraform.d
 


### PR DESCRIPTION
When working on fogg repos, its annoying to continuosly have to close files in my editor before i can easily use git status / git commit commands. This removes that noise.