### PR TITLE
[breaking] require account_id be set in defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ type TfLint struct {
 }
 
 type defaults struct {
-	AccountID          *int64            `json:"account_id,omitempty"`
+	AccountID          int64             `json:"account_id,omitempty" validate:"required"`
 	AWSProfileBackend  string            `json:"aws_profile_backend" validate:"required"`
 	AWSProfileProvider string            `json:"aws_profile_provider" validate:"required"`
 	AWSProviderVersion string            `json:"aws_provider_version" validate:"required"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,7 +48,7 @@ func TestParse(t *testing.T) {
 	c, e := ReadConfig(r)
 	assert.Nil(t, e)
 	assert.NotNil(t, c.Defaults)
-	assert.Equal(t, int64(1), *c.Defaults.AccountID)
+	assert.Equal(t, int64(1), c.Defaults.AccountID)
 	assert.Equal(t, "us-west-2", c.Defaults.AWSRegionBackend)
 	assert.Equal(t, "us-west-1", c.Defaults.AWSRegionProvider)
 	assert.Equal(t, "0.1.0", c.Defaults.AWSProviderVersion)
@@ -99,7 +99,7 @@ func TestValidation(t *testing.T) {
 
 	err, ok := e.(validator.ValidationErrors)
 	assert.True(t, ok)
-	assert.Len(t, err, 9)
+	assert.Len(t, err, 10)
 }
 
 func TestExtraVarsValidation(t *testing.T) {
@@ -107,6 +107,7 @@ func TestExtraVarsValidation(t *testing.T) {
 	{
 		"defaults": {
 			"aws_region_backend": "us-west-2",
+			"account_id": 123456789,
 			"aws_region_provider": "us-west-1",
 			"aws_profile_backend": "czi",
 			"aws_profile_provider": "czi",

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -16,7 +16,7 @@ const (
 
 // AWSConfiguration represents aws configuration
 type AWSConfiguration struct {
-	AccountID          *int64   `yaml:"account_id"`
+	AccountID          int64    `yaml:"account_id"`
 	AccountName        string   `yaml:"account_name"`
 	AWSProfileBackend  string   `yaml:"aws_profile_backend"`
 	AWSProfileProvider string   `yaml:"aws_profile_provider"`
@@ -149,7 +149,7 @@ func (p *Plan) buildAccounts(c *config.Config) map[string]Account {
 		accountPlan.DockerImageVersion = dockerImageVersion
 
 		accountPlan.AccountName = name
-		accountPlan.AccountID = resolveOptionalInt(c.Defaults.AccountID, config.AccountID)
+		accountPlan.AccountID = resolveRequiredInt(c.Defaults.AccountID, config.AccountID)
 
 		accountPlan.AWSRegionBackend = resolveRequired(defaults.AWSRegionBackend, config.AWSRegionBackend)
 		accountPlan.AWSRegionProvider = resolveRequired(defaults.AWSRegionProvider, config.AWSRegionProvider)
@@ -210,8 +210,6 @@ func (p *Plan) buildGlobal(conf *config.Config) Component {
 	componentPlan.AWSProfileBackend = conf.Defaults.AWSProfileBackend
 	componentPlan.AWSProfileProvider = conf.Defaults.AWSProfileProvider
 	componentPlan.AWSProviderVersion = conf.Defaults.AWSProviderVersion
-	// TODO add AccountID to defaults
-	// componentPlan.AccountID = conf.Defaults.AccountID
 
 	componentPlan.TerraformVersion = conf.Defaults.TerraformVersion
 	componentPlan.InfraBucket = conf.Defaults.InfraBucket
@@ -236,7 +234,7 @@ func (p *Plan) buildEnvs(conf *config.Config) (map[string]Env, error) {
 	for envName, envConf := range conf.Envs {
 		envPlan := newEnvPlan()
 
-		envPlan.AccountID = resolveOptionalInt(conf.Defaults.AccountID, envConf.AccountID)
+		envPlan.AccountID = resolveRequiredInt(conf.Defaults.AccountID, envConf.AccountID)
 		envPlan.Env = envName
 		envPlan.DockerImageVersion = dockerImageVersion
 
@@ -271,7 +269,7 @@ func (p *Plan) buildEnvs(conf *config.Config) (map[string]Env, error) {
 			}
 			componentPlan.Accounts = p.Accounts
 
-			componentPlan.AccountID = resolveOptionalInt(envPlan.AccountID, componentConf.AccountID)
+			componentPlan.AccountID = resolveRequiredInt(envPlan.AccountID, componentConf.AccountID)
 			componentPlan.AWSRegionBackend = resolveRequired(envPlan.AWSRegionBackend, componentConf.AWSRegionBackend)
 			componentPlan.AWSRegionProvider = resolveRequired(envPlan.AWSRegionProvider, componentConf.AWSRegionProvider)
 			componentPlan.AWSRegions = resolveStringArray(envPlan.AWSRegions, componentConf.AWSRegions)
@@ -279,7 +277,6 @@ func (p *Plan) buildEnvs(conf *config.Config) (map[string]Env, error) {
 			componentPlan.AWSProfileBackend = resolveRequired(envPlan.AWSProfileBackend, componentConf.AWSProfileBackend)
 			componentPlan.AWSProfileProvider = resolveRequired(envPlan.AWSProfileProvider, componentConf.AWSProfileProvider)
 			componentPlan.AWSProviderVersion = resolveRequired(envPlan.AWSProviderVersion, componentConf.AWSProviderVersion)
-			componentPlan.AccountID = resolveOptionalInt(envPlan.AccountID, componentConf.AccountID)
 
 			componentPlan.TerraformVersion = resolveRequired(envPlan.TerraformVersion, componentConf.TerraformVersion)
 			componentPlan.InfraBucket = resolveRequired(envPlan.InfraBucket, componentConf.InfraBucket)
@@ -350,6 +347,13 @@ func resolveStringArray(def []string, override []string) []string {
 }
 
 func resolveRequired(def string, override *string) string {
+	if override != nil {
+		return *override
+	}
+	return def
+}
+
+func resolveRequiredInt(def int64, override *int64) int64 {
 	if override != nil {
 		return *override
 	}

--- a/plan/travisci.go
+++ b/plan/travisci.go
@@ -33,7 +33,7 @@ func (p *Plan) buildTravisCI(c *config.Config, version string) TravisCI {
 			Name: name,
 			// TODO since accountID is required here, that means we need
 			// to make it non-optional, either in defaults or post-plan.
-			ID:   *p.Accounts[name].AccountID,
+			ID:   p.Accounts[name].AccountID,
 			Role: c.TravisCI.AWSIAMRoleName,
 		})
 	}


### PR DESCRIPTION
We defacto require this, since many features will just break if you don't have account ids set.

Fixes #223 