### PR TITLE
deprecate docker support

### DIFF
--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -271,8 +271,9 @@ func TestApplySmokeTest(t *testing.T) {
 	c2, e := config.UpgradeConfigVersion(c)
 	r.NoError(e)
 
-	e = c2.Validate()
+	w, e := c2.Validate()
 	r.NoError(e)
+	r.Len(w, 1)
 
 	e = Apply(fs, c2, templates.Templates, false)
 	r.NoError(e)

--- a/apply/golden_file_test.go
+++ b/apply/golden_file_test.go
@@ -54,8 +54,9 @@ func TestIntegration(t *testing.T) {
 				a.NoError(e)
 				fmt.Printf("conf %#v\n", conf)
 
-				e = conf.Validate()
+				w, e := conf.Validate()
 				a.NoError(e)
+				a.Len(w, 0)
 
 				e = apply.Apply(testdataFs, conf, templates.Templates, true)
 				a.NoError(e)
@@ -75,8 +76,9 @@ func TestIntegration(t *testing.T) {
 				a.NoError(e)
 				fmt.Printf("conf %#v\n", conf)
 
-				e = conf.Validate()
+				w, e := conf.Validate()
 				a.NoError(e)
+				a.Len(w, 0)
 
 				e = apply.Apply(fs, conf, templates.Templates, true)
 				a.NoError(e)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -41,7 +41,8 @@ var applyCmd = &cobra.Command{
 		// check that we are at root of initialized git repo
 		openGitOrExit(fs)
 
-		config, err := readAndValidateConfig(fs, configFile)
+		config, warnings, err := readAndValidateConfig(fs, configFile)
+		printWarnings(warnings)
 
 		e = mergeConfigValidationErrors(err)
 		if e != nil {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -39,7 +39,8 @@ var planCmd = &cobra.Command{
 		// check that we are at root of initialized git repo
 		openGitOrExit(fs)
 
-		config, err := readAndValidateConfig(fs, configFile)
+		config, warnings, err := readAndValidateConfig(fs, configFile)
+		printWarnings(warnings)
 
 		e = mergeConfigValidationErrors(err)
 		if e != nil {
@@ -50,6 +51,7 @@ var planCmd = &cobra.Command{
 		if e != nil {
 			return e
 		}
+
 		return plan.Print(p)
 	},
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -103,6 +103,6 @@ func bootstrapCmd(cmd *cobra.Command, debug bool) (afero.Fs, *v2.Config, error) 
 
 func printWarnings(warnings []string) {
 	for _, w := range warnings {
-		log.Warn(w)
+		logrus.Warn(w)
 	}
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -26,15 +26,16 @@ func openGitOrExit(fs afero.Fs) {
 	}
 }
 
-func readAndValidateConfig(fs afero.Fs, configFile string) (*v2.Config, error) {
+func readAndValidateConfig(fs afero.Fs, configFile string) (*v2.Config, []string, error) {
 	conf, err := config.FindAndReadConfig(fs, configFile)
 	if err != nil {
-		return nil, errs.WrapUser(err, "unable to read config file")
+		return nil, nil, errs.WrapUser(err, "unable to read config file")
 	}
 	log.Debug("CONFIG")
 	log.Debugf("%s\n=====", pretty.Sprint(conf))
 
-	return conf, conf.Validate()
+	warnings, e := conf.Validate()
+	return conf, warnings, e
 }
 
 func mergeConfigValidationErrors(err error) error {
@@ -90,7 +91,7 @@ func bootstrapCmd(cmd *cobra.Command, debug bool) (afero.Fs, *v2.Config, error) 
 		return nil, nil, err
 	}
 
-	config, err := readAndValidateConfig(fs, configFile)
+	config, _, err := readAndValidateConfig(fs, configFile)
 
 	err = mergeConfigValidationErrors(err)
 	if err != nil {
@@ -98,4 +99,10 @@ func bootstrapCmd(cmd *cobra.Command, debug bool) (afero.Fs, *v2.Config, error) 
 	}
 
 	return fs, config, nil
+}
+
+func printWarnings(warnings []string) {
+	for _, w := range warnings {
+		log.Warn(w)
+	}
 }

--- a/config/v2/config_test.go
+++ b/config/v2/config_test.go
@@ -16,8 +16,9 @@ func TestReadConfig(t *testing.T) {
 	c, e := ReadConfig(b)
 	a.NoError(e)
 
-	e = c.Validate()
+	w, e := c.Validate()
 	a.Error(e)
+	a.Len(w, 0)
 
 	b2, e := util.TestFile("v2_minimal_valid")
 	a.NoError(e)
@@ -25,9 +26,9 @@ func TestReadConfig(t *testing.T) {
 	c, e = ReadConfig(b2)
 	a.NoError(e)
 
-	e = c.Validate()
+	w, e = c.Validate()
 	a.NoError(e)
-
+	a.Len(w, 0)
 }
 
 func TestReadSnowflakeProvider(t *testing.T) {
@@ -41,8 +42,9 @@ func TestReadSnowflakeProvider(t *testing.T) {
 	r.NoError(e)
 	r.NotNil(c)
 
-	e = c.Validate()
+	w, e := c.Validate()
 	r.NoError(e)
+	r.Len(w, 0)
 
 	r.NotNil(c.Defaults.Providers)
 	r.NotNil(c.Defaults.Providers.Snowflake)

--- a/config/v2/validation.go
+++ b/config/v2/validation.go
@@ -12,11 +12,13 @@ import (
 )
 
 // Validate validates the config
-func (c *Config) Validate() error {
+func (c *Config) Validate() ([]string, error) {
 	if c == nil {
-		return errs.NewInternal("config is nil")
+		return nil, errs.NewInternal("config is nil")
 	}
+
 	var errs *multierror.Error
+	var warnings []string
 
 	v := validator.New()
 	// This func gives us the ability to get the full path for a field deeply
@@ -45,7 +47,11 @@ func (c *Config) Validate() error {
 	errs = multierror.Append(errs, c.ValidateSnowflakeProviders())
 	errs = multierror.Append(errs, c.validateModules())
 
-	return errs.ErrorOrNil()
+	if c.Docker {
+		warnings = append(warnings, "Docker support is deprecated and will be removed in a future version of fogg.")
+	}
+
+	return warnings, errs.ErrorOrNil()
 }
 
 func ValidateAWSProvider(p *AWSProvider, component string) error {

--- a/plan/plan_quick_test.go
+++ b/plan/plan_quick_test.go
@@ -16,7 +16,7 @@ func TestValidConfigNoPanic(t *testing.T) {
 	assertion := func(conf *v2.Config) bool {
 		// fmt.Printf("GOT %#v\n\n", pretty.Sprint(conf))
 		// validate our configuration
-		err := conf.Validate()
+		_, err := conf.Validate()
 
 		// if config is valid, there should be no panic
 		if err == nil {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -108,8 +108,9 @@ func TestPlanBasicV2(t *testing.T) {
 	c2, err := v2.ReadConfig(b)
 	assert.Nil(t, err)
 
-	err = c2.Validate()
+	w, err := c2.Validate()
 	a.NoError(err)
+	a.Len(w, 0)
 
 	plan, e := Eval(c2)
 	assert.Nil(t, e)

--- a/plan/travisci_test.go
+++ b/plan/travisci_test.go
@@ -70,8 +70,9 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 		}},
 	}
 
-	err := c.Validate()
+	w, err := c.Validate()
 	a.NoError(err)
+	a.Len(w, 0)
 
 	p := &Plan{}
 	p.Accounts = p.buildAccounts(c)
@@ -121,8 +122,9 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 		}},
 	}
 
-	err := c.Validate()
+	w, err := c.Validate()
 	a.NoError(err)
+	a.Len(w, 0)
 
 	p := &Plan{}
 	p.Accounts = p.buildAccounts(c)


### PR DESCRIPTION
We plan on removing support for running via docker in the future. This PR adds a simple mechanism for displaying warnings and adds one about docker support.

### Test Plan
* unit tests

### References
* Fixes #260