### PR TITLE
No race detector for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,14 @@ coverage: ## run the go coverage tool, reading file coverage.out
 	go tool cover -html=coverage.out
 
 test: dep ## run tests
-	gotest -race -cover ./...
+	gotest -cover ./...
 
 test-offline: dep ## run only tests that don't require internet
 	gotest -tags=offline ./...
 .PHONY: test-offline
 
 test-coverage: ## run the test with proper coverage reporting
-	goverage -race -coverprofile=coverage.out -covermode=atomic ./...
+	goverage -coverprofile=coverage.out -covermode=atomic ./...
 	go tool cover -html=coverage.out
 .PHONY: test-coverage
 


### PR DESCRIPTION
### Summary
We don't do any sort of coordination, goroutines, etc in this project. By removing the race tester, test durations drop from O(seconds) to O(centiseconds) per package. Might as well do this to speed up iteration cycles

### Test Plan
unittests

### References
