### PR TITLE
Add equal sign after config in providers

### DIFF
--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -85,7 +85,7 @@ variable "{{ $key }}" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "{{ .Backend.Bucket }}"
     {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Backend.DynamoTable }}"{{ end }}
     key            = "terraform/{{ .Project }}/global.tfstate"

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -103,7 +103,7 @@ variable "{{ $key }}" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "{{ .Backend.Bucket }}"
     {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Backend.DynamoTable }}"{{ end }}
     key            = "terraform/{{ .Project }}/global.tfstate"
@@ -117,7 +117,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "{{ $component }}" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "{{ $outer.Backend.Bucket }}"
     {{ if $outer.Backend.DynamoTable }}dynamodb_table = "{{ $outer.Backend.DynamoTable }}"{{ end }}
     key            = "terraform/{{ $outer.Project }}/envs/{{ $outer.Env }}/components/{{ $component }}.tfstate"
@@ -132,7 +132,7 @@ data "terraform_remote_state" "{{ $component }}" {
 data "terraform_remote_state" "{{ $accountName }}" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "{{ $account.Backend.Bucket }}"
     {{ if $account.Backend.DynamoTable }}dynamodb_table = "{{ $account.Backend.DynamoTable }}"{{ end }}
     key            = "terraform/{{ .Project }}/accounts/{{ $account.AccountName }}.tfstate"

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -103,7 +103,7 @@ variable "{{ $key }}" {
 data "terraform_remote_state" "{{ $component }}" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "{{ $outer.Backend.Bucket }}"
     {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Backend.DynamoTable }}"{{ end }}
     key            = "terraform/{{ $.Project }}/envs/{{ $outer.Env }}/components/{{ $component }}.tfstate"

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -38,7 +38,7 @@ variable "aws_accounts" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "bucket"
 
     key     = "terraform/foo/global.tfstate"

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -56,7 +56,7 @@ variable "tags" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "bucket"
 
     key     = "terraform/foo/global.tfstate"
@@ -70,7 +70,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "bucket"
 
     key     = "terraform/foo/accounts/foo.tfstate"

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -70,7 +70,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "bar-bucket"
     dynamodb_table = "bar-table"
     key            = "terraform/bar-project/global.tfstate"

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -70,7 +70,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "foo-bucket"
     dynamodb_table = "foo-table"
     key            = "terraform/foo-project/global.tfstate"

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -83,7 +83,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "env-bucket"
     dynamodb_table = "env-table"
     key            = "terraform/env-project/global.tfstate"
@@ -95,7 +95,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "helm" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "env-bucket"
     dynamodb_table = "env-table"
     key            = "terraform/env-project/envs/stage/components/helm.tfstate"
@@ -109,7 +109,7 @@ data "terraform_remote_state" "helm" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "bar-bucket"
     dynamodb_table = "bar-table"
     key            = "terraform/bar-project/accounts/bar.tfstate"
@@ -121,7 +121,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "foo-bucket"
     dynamodb_table = "foo-table"
     key            = "terraform/foo-project/accounts/foo.tfstate"

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -83,7 +83,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "stage-bucket"
     dynamodb_table = "stage-table"
     key            = "terraform/stage-project/global.tfstate"
@@ -95,7 +95,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "cloud-env" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "stage-bucket"
     dynamodb_table = "stage-table"
     key            = "terraform/stage-project/envs/stage/components/cloud-env.tfstate"
@@ -109,7 +109,7 @@ data "terraform_remote_state" "cloud-env" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "bar-bucket"
     dynamodb_table = "bar-table"
     key            = "terraform/bar-project/accounts/bar.tfstate"
@@ -121,7 +121,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket         = "foo-bucket"
     dynamodb_table = "foo-table"
     key            = "terraform/foo-project/accounts/foo.tfstate"

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -62,7 +62,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -62,7 +62,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -74,7 +74,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"
@@ -86,7 +86,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "comp2" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp2.tfstate"
@@ -98,7 +98,7 @@ data "terraform_remote_state" "comp2" {
 data "terraform_remote_state" "vpc" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/vpc.tfstate"
@@ -112,7 +112,7 @@ data "terraform_remote_state" "vpc" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/bar.tfstate"
@@ -124,7 +124,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/foo.tfstate"

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -74,7 +74,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"
@@ -86,7 +86,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "comp1" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp1.tfstate"
@@ -98,7 +98,7 @@ data "terraform_remote_state" "comp1" {
 data "terraform_remote_state" "vpc" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/vpc.tfstate"
@@ -112,7 +112,7 @@ data "terraform_remote_state" "vpc" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/bar.tfstate"
@@ -124,7 +124,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/foo.tfstate"

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -74,7 +74,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"
@@ -86,7 +86,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "comp1" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp1.tfstate"
@@ -98,7 +98,7 @@ data "terraform_remote_state" "comp1" {
 data "terraform_remote_state" "comp2" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp2.tfstate"
@@ -112,7 +112,7 @@ data "terraform_remote_state" "comp2" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/bar.tfstate"
@@ -124,7 +124,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/foo.tfstate"

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -37,7 +37,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -37,7 +37,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -55,7 +55,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"
@@ -67,7 +67,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "comp2" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp2.tfstate"
@@ -79,7 +79,7 @@ data "terraform_remote_state" "comp2" {
 data "terraform_remote_state" "vpc" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/vpc.tfstate"
@@ -93,7 +93,7 @@ data "terraform_remote_state" "vpc" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/bar.tfstate"
@@ -105,7 +105,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/foo.tfstate"

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -55,7 +55,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"
@@ -67,7 +67,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "comp1" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp1.tfstate"
@@ -79,7 +79,7 @@ data "terraform_remote_state" "comp1" {
 data "terraform_remote_state" "vpc" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/vpc.tfstate"
@@ -93,7 +93,7 @@ data "terraform_remote_state" "vpc" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/bar.tfstate"
@@ -105,7 +105,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/foo.tfstate"

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -55,7 +55,7 @@ variable "foo" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/global.tfstate"
@@ -67,7 +67,7 @@ data "terraform_remote_state" "global" {
 data "terraform_remote_state" "comp1" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp1.tfstate"
@@ -79,7 +79,7 @@ data "terraform_remote_state" "comp1" {
 data "terraform_remote_state" "comp2" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/envs/staging/components/comp2.tfstate"
@@ -93,7 +93,7 @@ data "terraform_remote_state" "comp2" {
 data "terraform_remote_state" "bar" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/bar.tfstate"
@@ -105,7 +105,7 @@ data "terraform_remote_state" "bar" {
 data "terraform_remote_state" "foo" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "buck"
 
     key     = "terraform/proj/accounts/foo.tfstate"


### PR DESCRIPTION
### Summary
For future 0.12 compatibility, this PR modifies fogg to add an equal "`=`" sign between the word `config` and the brace "`{`" inside of `provider` blocks. Hopefully this should be the only change to make fogg generate output that is simultaneously compatible with 0.11 and 0.12. Longer term, there are other changes to make it closer to 0.12 (e.g. some dropping of quotes and "${"), but this should not be needed right now.

### Test Plan
Still passes existing tests.

### References
https://www.terraform.io/upgrade-guides/0-12.html#attributes-vs-blocks
