### PR TITLE
Use top-level default settings for global

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -93,6 +93,7 @@ type Account struct {
 
 	AllAccounts map[string]int64 `yaml:"all_accounts"`
 	AccountName string           `yaml:"account_name"`
+	Global      *Component
 }
 
 // Component is a component
@@ -107,6 +108,7 @@ type Component struct {
 	Kind            *v1.ComponentKind `yaml:"kind,omitempty"`
 	ModuleSource    *string           `yaml:"module_source"`
 	OtherComponents []string          `yaml:"other_components"`
+	Global          *Component
 }
 
 // Env is an env
@@ -134,12 +136,12 @@ func Eval(c *v2.Config) (*Plan, error) {
 	p.Version = v
 
 	var err error
+	p.Global = p.buildGlobal(c)
 	p.Accounts = p.buildAccounts(c)
 	p.Envs, err = p.buildEnvs(c)
 	if err != nil {
 		return nil, err
 	}
-	p.Global = p.buildGlobal(c)
 	p.Modules = p.buildModules(c)
 
 	if c.Tools.TravisCI != nil {
@@ -173,6 +175,7 @@ func (p *Plan) buildAccounts(c *v2.Config) map[string]Account {
 		accountPlan.PathToRepoRoot = "../../../"
 		accountPlan.Docker = c.Docker
 		accountPlan.DockerImageVersion = dockerImageVersion
+		accountPlan.Global = &p.Global
 
 		accountPlans[name] = accountPlan
 	}
@@ -256,6 +259,7 @@ func (p *Plan) buildEnvs(conf *v2.Config) (map[string]Env, error) {
 
 			componentPlan.TfLint = resolveTfLint(conf.Tools.TfLint, nil)
 			componentPlan.Docker = conf.Docker
+			componentPlan.Global = &p.Global
 
 			envPlan.Components[componentName] = componentPlan
 		}

--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -92,10 +92,10 @@ data "terraform_remote_state" "global" {
   backend = "s3"
 
   config = {
-    bucket         = "{{ .Backend.Bucket }}"
-    {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Backend.DynamoTable }}"{{ end }}
-    key            = "terraform/{{ .Project }}/global.tfstate"
-    region         = "{{ .Backend.Region }}"
-    {{ if .Backend.Profile }}profile        = "{{ .Backend.Profile }}"{{ end }}
+    bucket         = "{{ .Global.Backend.Bucket }}"
+    {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Global.Backend.DynamoTable }}"{{ end }}
+    key            = "terraform/{{ .Global.Project }}/global.tfstate"
+    region         = "{{ .Global.Backend.Region }}"
+    {{ if .Global.Backend.Profile }}profile        = "{{ .Global.Backend.Profile }}"{{ end }}
   }
 }

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -109,11 +109,11 @@ data "terraform_remote_state" "global" {
   backend = "s3"
 
   config = {
-    bucket         = "{{ .Backend.Bucket }}"
-    {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Backend.DynamoTable }}"{{ end }}
-    key            = "terraform/{{ .Project }}/global.tfstate"
-    region         = "{{ .Backend.Region }}"
-    {{ if .Backend.Profile }}profile        = "{{ .Backend.Profile }}"{{ end }}
+    bucket         = "{{ .Global.Backend.Bucket }}"
+    {{ if .Backend.DynamoTable }}dynamodb_table = "{{ .Global.Backend.DynamoTable }}"{{ end }}
+    key            = "terraform/{{ .Global.Project }}/global.tfstate"
+    region         = "{{ .Global.Backend.Region }}"
+    {{ if .Global.Backend.Profile }}profile        = "{{ .Global.Backend.Profile }}"{{ end }}
   }
 }
 

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -71,10 +71,10 @@ data "terraform_remote_state" "global" {
   backend = "s3"
 
   config = {
-    bucket         = "bar-bucket"
-    dynamodb_table = "bar-table"
-    key            = "terraform/bar-project/global.tfstate"
-    region         = "us-west-bar1"
-    profile        = "czi-bar"
+    bucket         = "the-bucket"
+    dynamodb_table = "the-table"
+    key            = "terraform/test-project/global.tfstate"
+    region         = "us-west-2"
+    profile        = "czi"
   }
 }

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -71,10 +71,10 @@ data "terraform_remote_state" "global" {
   backend = "s3"
 
   config = {
-    bucket         = "foo-bucket"
-    dynamodb_table = "foo-table"
-    key            = "terraform/foo-project/global.tfstate"
-    region         = "us-west-foo1"
-    profile        = "czi-foo"
+    bucket         = "the-bucket"
+    dynamodb_table = "the-table"
+    key            = "terraform/test-project/global.tfstate"
+    region         = "us-west-2"
+    profile        = "czi"
   }
 }

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -84,11 +84,11 @@ data "terraform_remote_state" "global" {
   backend = "s3"
 
   config = {
-    bucket         = "env-bucket"
-    dynamodb_table = "env-table"
-    key            = "terraform/env-project/global.tfstate"
-    region         = "us-west-env1"
-    profile        = "czi-env"
+    bucket         = "the-bucket"
+    dynamodb_table = "the-table"
+    key            = "terraform/test-project/global.tfstate"
+    region         = "us-west-2"
+    profile        = "czi"
   }
 }
 

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -84,11 +84,11 @@ data "terraform_remote_state" "global" {
   backend = "s3"
 
   config = {
-    bucket         = "stage-bucket"
-    dynamodb_table = "stage-table"
-    key            = "terraform/stage-project/global.tfstate"
-    region         = "us-west-stage1"
-    profile        = "czi-stage"
+    bucket         = "the-bucket"
+    dynamodb_table = "the-table"
+    key            = "terraform/test-project/global.tfstate"
+    region         = "us-west-2"
+    profile        = "czi"
   }
 }
 

--- a/testdata/v2_full/fogg.json
+++ b/testdata/v2_full/fogg.json
@@ -52,7 +52,11 @@
             "foo": "bar3"
           }
         },
-        "comp1": {},
+        "comp1": {
+          "backend": {
+            "profile": "comp1"
+          }
+        },
         "comp2": {},
         "comp_helm_template": {
           "kind": "helm_template",

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -20,7 +20,7 @@ terraform {
 
     encrypt = true
     region  = "us-west-2"
-    profile = "profile"
+    profile = "comp1"
   }
 }
 
@@ -91,7 +91,7 @@ data "terraform_remote_state" "comp2" {
 
     key     = "terraform/proj/envs/staging/components/comp2.tfstate"
     region  = "us-west-2"
-    profile = "profile"
+    profile = "comp1"
   }
 }
 
@@ -103,7 +103,7 @@ data "terraform_remote_state" "vpc" {
 
     key     = "terraform/proj/envs/staging/components/vpc.tfstate"
     region  = "us-west-2"
-    profile = "profile"
+    profile = "comp1"
   }
 }
 


### PR DESCRIPTION
### Summary
Changes the generated fogg output to use the top-level defaults when rendering the terraform_remote_state pointing at "global" component, which make sit properly reflect the bucket and path of the global component instead of getting overridden by any account/component level override.

Note that this may have an effect of using the top-level default AWS profile for global instead of any override too. In the particular case of AWS profile, this may not be the desired behavior.

### Test Plan
Existing golden file tests were updated to reflect the correct output. A test case was added to the v2_full staging/comp1 component to reflect an override of the profile at the component level.
