### PR TITLE
try buildmetrics for tracking builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ install:
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
   - echo $PATH
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm install -g snyk
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make setup
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go get -u github.com/haya14busa/goverage
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make-setup -- make setup
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go-get -- go get -u github.com/haya14busa/goverage
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ install:
   - mkdir bin # this is in theory supposed to exist already
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
-  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm install -g snyk
-  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make setup
-  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go get -u github.com/haya14busa/goverage
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm install -g snyk
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make setup
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go get -u github.com/haya14busa/goverage
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ install:
   - mkdir bin # this is in theory supposed to exist already
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm install -g snyk
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make setup
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go get -u github.com/haya14busa/goverage
+  - echo $PATH
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm install -g snyk
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make setup
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go get -u github.com/haya14busa/goverage
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 sudo: false
 go:
   - "1.12"
+env:
+  global:
+    - BUILD_START=$(date +%s)
+
 install:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
@@ -13,19 +17,21 @@ install:
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
 
 script:
-  - make
+  - STEP_START=$(date +%s)
+  - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID codecov-validate -- curl --data-binary @codecov.yml https://codecov.io/validate
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make-test-coverage -- make test-coverage
+# Disable snyk until https://github.com/snyk/snyk/issues/354 is resolved
+#     - if [[ ! -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi
 
-jobs:
-  include:
-    - stage: check
-      script:
-        - make test-coverage
-      after_success:
-        - bash <(curl -s https://codecov.io/bash)
-    # Disable snyk until https://github.com/snyk/snyk/issues/354 is resolved
-    # - stage: check
-    #   script:
-    #     - if [[ ! -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi
-    - stage: check
-      script:
-        - curl --data-binary @codecov.yml https://codecov.io/validate
+after_failure:
+  - buildevents travis-ci build $TRAVIS_BUILD_ID $BUILD_START failure
+
+after_success:
+  - STEP_START=$(date +%s)
+  - STEP_SPAN_ID=$(echo after_success | sum | cut -f 1 -d \ )
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID codecov-upload -- bash <(curl -s https://codecov.io/bash)
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID build -- go install ./...
+  - # ... tar up artifacts, upload them, etc.
+  - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START after_success
+  - buildevents build $TRAVIS_BUILD_ID $BUILD_START success

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ sudo: false
 go:
   - "1.12"
 install:
+  - STEP_START=$(date +%s)
+  - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
   - mkdir bin # this is in theory supposed to exist already
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
   - echo $PATH
-  # - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
   - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make_setup -- make setup
   - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,23 +15,24 @@ install:
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make_setup -- make setup
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
+  - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START install
 
 script:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID codecov-validate -- curl --data-binary @codecov.yml https://codecov.io/validate
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make-test-coverage -- make test-coverage
-# Disable snyk until https://github.com/snyk/snyk/issues/354 is resolved
-#     - if [[ ! -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi
+  # Disable snyk until https://github.com/snyk/snyk/issues/354 is resolved
+  # - if [[ ! -z "${SNYK_TOKEN}" ]]; then snyk monitor --org=czi; snyk test; fi
+  - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START script
 
 after_failure:
+  - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START after_failure
   - buildevents travis-ci build $TRAVIS_BUILD_ID $BUILD_START failure
 
 after_success:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo after_success | sum | cut -f 1 -d \ )
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID codecov-upload -- bash <(curl -s https://codecov.io/bash)
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID build -- go install ./...
-  - # ... tar up artifacts, upload them, etc.
   - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START after_success
   - buildevents build $TRAVIS_BUILD_ID $BUILD_START success

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - curl -L -o $HOME/bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 $HOME/bin/buildevents
   - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make_setup -- make setup
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make-setup -- make setup
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go-get -- go get -u github.com/haya14busa/goverage
   - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START install
 
 script:
@@ -27,6 +27,8 @@ script:
   - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START script
 
 after_failure:
+  - STEP_START=$(date +%s)
+  - STEP_SPAN_ID=$(echo after_success | sum | cut -f 1 -d \ )
   - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START after_failure
   - buildevents travis-ci build $TRAVIS_BUILD_ID $BUILD_START failure
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false
 go:
   - "1.12"
 install:
-  - mkdir bin
+  - mkdir bin # this is in theory supposed to exist already
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
-  - npm install -g snyk
-  - make setup
-  - go get -u github.com/haya14busa/goverage
+  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm install -g snyk
+  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make setup
+  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go get -u github.com/haya14busa/goverage
 
 script:
   - make
@@ -18,6 +18,7 @@ jobs:
     - stage: check
       script:
         - make test-coverage
+      after_success:
         - bash <(curl -s https://codecov.io/bash)
     # Disable snyk until https://github.com/snyk/snyk/issues/354 is resolved
     # - stage: check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: go
+sudo: false
 go:
-  - "1.11"
+  - "1.12"
 install:
+  - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+  - chmod 755 bin/buildevents
   - npm install -g snyk
   - make setup
   - go get -u github.com/haya14busa/goverage
-  - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
-  - chmod 755 bin/buildevents
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ install:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
   - mkdir bin # this is in theory supposed to exist already
-  - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
-  - chmod 755 bin/buildevents
-  - echo $PATH
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make_setup -- make setup
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
+  - curl -L -o $HOME/bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+  - chmod 755 $HOME/bin/buildevents
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make_setup -- make setup
+  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ install:
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
   - echo $PATH
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make-setup -- make setup
-  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go-get -- go get -u github.com/haya14busa/goverage
+  # - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID npm-install -- npm install -g snyk
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID make_setup -- make setup
+  - ./bin/buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go_get -- go get -u github.com/haya14busa/goverage
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ install:
   - npm install -g snyk
   - make setup
   - go get -u github.com/haya14busa/goverage
+  - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+  - chmod 755 bin/buildevents
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 go:
   - "1.12"
 install:
+  - mkdir bin
   - curl -L -o bin/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
   - chmod 755 bin/buildevents
   - npm install -g snyk


### PR DESCRIPTION
I set out to try and find ways to instrument our builds and this is the best option I have found.

This travis build will now use honeycomb's [buildmetrics](https://github.com/honeycombio/buildevents) to trace the build through its execution. We can then analyze the data and alert on any SLIs we care about.

I looked at datadog integration, but their metrics don't include the branch name (because it is high cardinality), so you can't do things like "only alert on master branch failures". Honeycomb, with support for high-cardinality metrics should allow us to do this.

### Test Plan
* travis build

### References
* https://github.com/honeycombio/buildevents
