### PR TITLE
refactor: move tools to common

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -130,16 +130,11 @@ func UpgradeConfigVersion(c1 *v1.Config) (*v2.Config, error) {
 			Owner:            util.StrPtr(def1.Owner),
 			Project:          util.StrPtr(def1.Project),
 			TerraformVersion: util.StrPtr(def1.TerraformVersion),
+			Tools: v2.Tools{
+				TfLint:   def1.TfLint,
+				TravisCI: c1.TravisCI,
+			},
 		},
-	}
-
-	c2.Tools = v2.Tools{}
-	if def1.TfLint != nil {
-		c2.Tools.TfLint = def1.TfLint
-	}
-
-	if c1.TravisCI != nil {
-		c2.Tools.TravisCI = c1.TravisCI
 	}
 
 	for acctName, acct := range c1.Accounts {

--- a/config/config.go
+++ b/config/config.go
@@ -130,7 +130,7 @@ func UpgradeConfigVersion(c1 *v1.Config) (*v2.Config, error) {
 			Owner:            util.StrPtr(def1.Owner),
 			Project:          util.StrPtr(def1.Project),
 			TerraformVersion: util.StrPtr(def1.TerraformVersion),
-			Tools: v2.Tools{
+			Tools: &v2.Tools{
 				TfLint:   def1.TfLint,
 				TravisCI: c1.TravisCI,
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,7 +99,7 @@ func TestUpgradeConfigVersion(t *testing.T) {
 				Project:          util.StrPtr("test-project"),
 				ExtraVars:        map[string]string{"foo": "bar"},
 				TerraformVersion: util.StrPtr("0.11.0"),
-				Tools: v2.Tools{
+				Tools: &v2.Tools{
 					TfLint: &v1.TfLint{
 						Enabled: boolptr(true),
 					},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,18 +99,19 @@ func TestUpgradeConfigVersion(t *testing.T) {
 				Project:          util.StrPtr("test-project"),
 				ExtraVars:        map[string]string{"foo": "bar"},
 				TerraformVersion: util.StrPtr("0.11.0"),
+				Tools: v2.Tools{
+					TfLint: &v1.TfLint{
+						Enabled: boolptr(true),
+					},
+					TravisCI: &v1.TravisCI{
+						Enabled:        true,
+						AWSIAMRoleName: "travis-role",
+						TestBuckets:    13,
+					},
+				},
 			},
 		},
-		Tools: v2.Tools{
-			TfLint: &v1.TfLint{
-				Enabled: boolptr(true),
-			},
-			TravisCI: &v1.TravisCI{
-				Enabled:        true,
-				AWSIAMRoleName: "travis-role",
-				TestBuckets:    13,
-			},
-		},
+
 		Accounts: map[string]v2.Account{
 			"foo": v2.Account{
 				Common: v2.Common{

--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -37,7 +37,7 @@ type Common struct {
 	Project          *string           `json:"project,omitempty" `
 	Providers        *Providers        `json:"providers,omitempty" `
 	TerraformVersion *string           `json:"terraform_version,omitempty"`
-	Tools            Tools             `json:"tools,omitempty"`
+	Tools            *Tools            `json:"tools,omitempty"`
 }
 
 type Defaults struct {
@@ -203,12 +203,20 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 			},
 			TerraformVersion: randStringPtr(r, s),
 		}
-		c.Tools = Tools{}
 
 		if r.Float32() < 0.5 {
-			c.Tools.TravisCI = &v1.TravisCI{
-				Enabled:     r.Float32() < 0.5,
-				TestBuckets: r.Intn(size),
+			c.Tools = &Tools{}
+			if r.Float32() < 0.5 {
+				c.Tools.TravisCI = &v1.TravisCI{
+					Enabled:     r.Float32() < 0.5,
+					TestBuckets: r.Intn(size),
+				}
+			}
+			if r.Float32() < 0.5 {
+				p := r.Float32() < 0.5
+				c.Tools.TfLint = &v1.TfLint{
+					Enabled: &p,
+				}
 			}
 		}
 

--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	Global   Component            `json:"global,omitempty"`
 	Modules  map[string]v1.Module `json:"modules,omitempty"`
 	Plugins  v1.Plugins           `json:"plugins,omitempty"`
-	Tools    Tools                `json:"tools,omitempty"`
 	Version  int                  `json:"version" validate:"required,eq=2"`
 }
 
@@ -38,6 +37,7 @@ type Common struct {
 	Project          *string           `json:"project,omitempty" `
 	Providers        *Providers        `json:"providers,omitempty" `
 	TerraformVersion *string           `json:"terraform_version,omitempty"`
+	Tools            Tools             `json:"tools,omitempty"`
 }
 
 type Defaults struct {
@@ -203,6 +203,15 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 			},
 			TerraformVersion: randStringPtr(r, s),
 		}
+		c.Tools = Tools{}
+
+		if r.Float32() < 0.5 {
+			c.Tools.TravisCI = &v1.TravisCI{
+				Enabled:     r.Float32() < 0.5,
+				TestBuckets: r.Intn(size),
+			}
+		}
+
 		return c
 	}
 
@@ -213,15 +222,6 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 	}
 
 	// tools
-
-	conf.Tools = Tools{}
-
-	if r.Float32() < 0.5 {
-		conf.Tools.TravisCI = &v1.TravisCI{
-			Enabled:     r.Float32() < 0.5,
-			TestBuckets: r.Intn(size),
-		}
-	}
 
 	conf.Accounts = map[string]Account{}
 	acctN := r.Intn(size)

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -138,7 +138,7 @@ func ResolveBlessProvider(commons ...Common) *BlessProvider {
 func ResolveTfLint(commons ...Common) v1.TfLint {
 	enabled := false
 	for _, c := range commons {
-		if c.Tools.TfLint != nil && c.Tools.TfLint.Enabled != nil {
+		if c.Tools != nil && c.Tools.TfLint != nil && c.Tools.TfLint.Enabled != nil {
 			enabled = *c.Tools.TfLint.Enabled
 		}
 	}

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -135,6 +135,19 @@ func ResolveBlessProvider(commons ...Common) *BlessProvider {
 	}
 }
 
+func ResolveTfLint(commons ...Common) v1.TfLint {
+	enabled := false
+	for _, c := range commons {
+		if c.Tools.TfLint != nil && c.Tools.TfLint.Enabled != nil {
+			enabled = *c.Tools.TfLint.Enabled
+		}
+	}
+
+	return v1.TfLint{
+		Enabled: &enabled,
+	}
+}
+
 func OwnerGetter(comm Common) *string {
 	return comm.Owner
 }

--- a/config/v2/resolvers_test.go
+++ b/config/v2/resolvers_test.go
@@ -1,0 +1,39 @@
+package v2_test
+
+import (
+	"testing"
+
+	"github.com/chanzuckerberg/fogg/config/v1"
+	"github.com/chanzuckerberg/fogg/config/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveTfLint(test *testing.T) {
+	a := assert.New(test)
+	t := true
+	f := false
+
+	data := []struct {
+		def    *bool
+		over   *bool
+		output *bool
+	}{
+		{nil, nil, &f},
+		{nil, &t, &t},
+		{nil, &f, &f},
+		{&t, nil, &t},
+		{&t, &t, &t},
+		{&t, &f, &f},
+		{&f, nil, &f},
+		{&f, &t, &t},
+		{&f, &f, &f},
+	}
+	for _, r := range data {
+		test.Run("", func(t *testing.T) {
+			def := v2.Common{Tools: v2.Tools{TfLint: &v1.TfLint{Enabled: r.def}}}
+			over := v2.Common{Tools: v2.Tools{TfLint: &v1.TfLint{Enabled: r.over}}}
+			result := v2.ResolveTfLint(def, over)
+			a.Equal(r.output, result.Enabled)
+		})
+	}
+}

--- a/config/v2/resolvers_test.go
+++ b/config/v2/resolvers_test.go
@@ -30,8 +30,8 @@ func TestResolveTfLint(test *testing.T) {
 	}
 	for _, r := range data {
 		test.Run("", func(t *testing.T) {
-			def := v2.Common{Tools: v2.Tools{TfLint: &v1.TfLint{Enabled: r.def}}}
-			over := v2.Common{Tools: v2.Tools{TfLint: &v1.TfLint{Enabled: r.over}}}
+			def := v2.Common{Tools: &v2.Tools{TfLint: &v1.TfLint{Enabled: r.def}}}
+			over := v2.Common{Tools: &v2.Tools{TfLint: &v1.TfLint{Enabled: r.over}}}
 			result := v2.ResolveTfLint(def, over)
 			a.Equal(r.output, result.Enabled)
 		})

--- a/config/v2/validation.go
+++ b/config/v2/validation.go
@@ -48,11 +48,23 @@ func (c *Config) Validate() ([]string, error) {
 	errs = multierror.Append(errs, c.ValidateBlessProviders())
 	errs = multierror.Append(errs, c.validateModules())
 
+	// refactor to make it easier to manage these
+	w, e := c.ValidateToolsTravis()
+	warnings = append(warnings, w...)
+	errs = multierror.Append(errs, e)
+	w, e = c.ValidateToolsTfLint()
+	warnings = append(warnings, w...)
+	errs = multierror.Append(errs, e)
+
 	if c.Docker {
 		warnings = append(warnings, "Docker support is no longer supported and the config entry is ignored.")
 	}
 
 	return warnings, errs.ErrorOrNil()
+}
+
+func merge(warnings []string, err *multierror.Error, w []string, e error) ([]string, *multierror.Error) {
+	return append(warnings, w...), multierror.Append(err, e)
 }
 
 func ValidateAWSProvider(p *AWSProvider, component string) error {
@@ -152,6 +164,31 @@ func (c *Config) ValidateBlessProviders() error {
 	return errs
 }
 
+func (c *Config) ValidateToolsTravis() ([]string, error) {
+	var warns []string
+	var errs *multierror.Error
+	c.WalkComponents(func(component string, comms ...Common) {
+		c := comms[len(comms)-1]
+		if c.Tools != nil && c.Tools.TravisCI != nil {
+			warns = append(warns, fmt.Sprintf("per-component travisci config is not implemented, ignoring config in %s", component))
+		}
+	})
+
+	return warns, errs
+}
+
+func (c *Config) ValidateToolsTfLint() ([]string, error) {
+	var warns []string
+	var errs *multierror.Error
+	c.WalkComponents(func(component string, comms ...Common) {
+		c := comms[len(comms)-1]
+		if c.Tools != nil && c.Tools.TfLint != nil {
+			warns = append(warns, fmt.Sprintf("per-component tflint config is not implemented, ignoring config in %s", component))
+		}
+	})
+
+	return warns, errs
+}
 func (c *Config) WalkComponents(f func(component string, commons ...Common)) {
 	for name, acct := range c.Accounts {
 		f(fmt.Sprintf("accounts/%s", name), c.Defaults.Common, acct.Common)

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -166,63 +166,6 @@ func TestExtraVarsCompositionV2(t *testing.T) {
 
 }
 
-func TestResolveTfLint(test *testing.T) {
-	a := assert.New(test)
-	t := true
-	f := false
-
-	data := []struct {
-		def    *bool
-		over   *bool
-		output bool
-	}{
-		{nil, nil, false},
-		{nil, &t, true},
-		{nil, &f, false},
-		{&t, nil, true},
-		{&t, &t, true},
-		{&t, &f, false},
-		{&f, nil, false},
-		{&f, &t, true},
-		{&f, &f, false},
-	}
-	for _, r := range data {
-		test.Run("", func(t *testing.T) {
-			def := &v1.TfLint{Enabled: r.def}
-			over := &v1.TfLint{Enabled: r.over}
-			result := resolveTfLint(def, over)
-			a.Equal(r.output, result.Enabled)
-		})
-	}
-}
-
-func TestResolveTfLintComponent(test *testing.T) {
-	a := assert.New(test)
-	t := true
-	f := false
-
-	data := []struct {
-		def    bool
-		over   *bool
-		output bool
-	}{
-		{t, nil, true},
-		{t, &t, true},
-		{t, &f, false},
-		{f, nil, false},
-		{f, &t, true},
-		{f, &f, false},
-	}
-	for _, r := range data {
-		test.Run("", func(t *testing.T) {
-			def := TfLint{Enabled: r.def}
-			over := &v1.TfLint{Enabled: r.over}
-			result := resolveTfLintComponent(def, over)
-			a.Equal(r.output, result.Enabled)
-		})
-	}
-}
-
 func TestResolveEKSConfig(t *testing.T) {
 	a := assert.New(t)
 	a.Equal("", resolveEKSConfig(nil, nil).ClusterName)

--- a/plan/travisci.go
+++ b/plan/travisci.go
@@ -25,8 +25,12 @@ func (p *Plan) buildTravisCI(c *v2.Config, version string) TravisCI {
 		panic("buildTravisCI must be run after buildAccounts")
 	}
 
+	if c.Defaults.Tools.TravisCI == nil {
+		return TravisCI{}
+	}
+
 	tr := TravisCI{
-		Enabled: c.Tools.TravisCI.Enabled,
+		Enabled: c.Defaults.Tools.TravisCI.Enabled,
 	}
 	var profiles []AWSProfile
 
@@ -38,14 +42,14 @@ func (p *Plan) buildTravisCI(c *v2.Config, version string) TravisCI {
 			// TODO since accountID is required here, that means we need
 			// to make it non-optional, either in defaults or post-plan.
 			ID:   p.Accounts[name].Providers.AWS.AccountID,
-			Role: c.Tools.TravisCI.AWSIAMRoleName,
+			Role: c.Defaults.Tools.TravisCI.AWSIAMRoleName,
 		})
 	}
 	tr.AWSProfiles = profiles
 
 	var buckets int
-	if c.Tools.TravisCI.TestBuckets > 0 {
-		buckets = c.Tools.TravisCI.TestBuckets
+	if c.Defaults.Tools.TravisCI.TestBuckets > 0 {
+		buckets = c.Defaults.Tools.TravisCI.TestBuckets
 	} else {
 		buckets = 1
 	}

--- a/plan/travisci.go
+++ b/plan/travisci.go
@@ -25,7 +25,7 @@ func (p *Plan) buildTravisCI(c *v2.Config, version string) TravisCI {
 		panic("buildTravisCI must be run after buildAccounts")
 	}
 
-	if c.Defaults.Tools.TravisCI == nil {
+	if c.Defaults.Tools == nil || c.Defaults.Tools.TravisCI == nil {
 		return TravisCI{}
 	}
 

--- a/plan/travisci_test.go
+++ b/plan/travisci_test.go
@@ -22,7 +22,7 @@ func Test_buildTravisCI_Disabled(t *testing.T) {
 		c := &v2.Config{
 			Defaults: v2.Defaults{
 				Common: v2.Common{
-					Tools: v2.Tools{
+					Tools: &v2.Tools{
 						TravisCI: &v1.TravisCI{
 							Enabled: false,
 						},
@@ -61,7 +61,7 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 					Region:  util.StrPtr("us-west-2"),
 					Profile: util.StrPtr("profile"),
 				},
-				Tools: v2.Tools{TravisCI: &v1.TravisCI{
+				Tools: &v2.Tools{TravisCI: &v1.TravisCI{
 					Enabled:        true,
 					AWSIAMRoleName: "rollin",
 				}},
@@ -110,7 +110,7 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 					Region:  util.StrPtr("us-west-2"),
 					Profile: util.StrPtr("profile"),
 				},
-				Tools: v2.Tools{TravisCI: &v1.TravisCI{
+				Tools: &v2.Tools{TravisCI: &v1.TravisCI{
 					Enabled:        true,
 					AWSIAMRoleName: "rollin",
 				}},

--- a/plan/travisci_test.go
+++ b/plan/travisci_test.go
@@ -20,9 +20,13 @@ func Test_buildTravisCI_Disabled(t *testing.T) {
 	a := assert.New(t)
 	{
 		c := &v2.Config{
-			Tools: v2.Tools{
-				TravisCI: &v1.TravisCI{
-					Enabled: false,
+			Defaults: v2.Defaults{
+				Common: v2.Common{
+					Tools: v2.Tools{
+						TravisCI: &v1.TravisCI{
+							Enabled: false,
+						},
+					},
 				},
 			},
 		}
@@ -57,6 +61,10 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 					Region:  util.StrPtr("us-west-2"),
 					Profile: util.StrPtr("profile"),
 				},
+				Tools: v2.Tools{TravisCI: &v1.TravisCI{
+					Enabled:        true,
+					AWSIAMRoleName: "rollin",
+				}},
 			},
 		},
 		Accounts: map[string]v2.Account{
@@ -64,10 +72,6 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 				Common: v2.Common{Providers: &v2.Providers{AWS: &v2.AWSProvider{AccountID: &id1}}},
 			},
 		},
-		Tools: v2.Tools{TravisCI: &v1.TravisCI{
-			Enabled:        true,
-			AWSIAMRoleName: "rollin",
-		}},
 	}
 
 	w, err := c.Validate()
@@ -106,6 +110,10 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 					Region:  util.StrPtr("us-west-2"),
 					Profile: util.StrPtr("profile"),
 				},
+				Tools: v2.Tools{TravisCI: &v1.TravisCI{
+					Enabled:        true,
+					AWSIAMRoleName: "rollin",
+				}},
 			},
 		},
 		Accounts: map[string]v2.Account{
@@ -116,10 +124,6 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 				Common: v2.Common{Providers: &v2.Providers{AWS: &v2.AWSProvider{AccountID: &id2}}},
 			},
 		},
-		Tools: v2.Tools{TravisCI: &v1.TravisCI{
-			Enabled:        true,
-			AWSIAMRoleName: "rollin",
-		}},
 	}
 
 	w, err := c.Validate()


### PR DESCRIPTION
Before this tools could only be defined at the top level (not per-component).

We would like to be able to configure Atlantis separately for each component. As a bonus this will allow us to do the same for the other tools.

Note that this is a breaking change for config v2, but given that it isn't deployed widely I think we can get away with it.

### Test Plan
* unit tests

### References
*
