### PR TITLE
[fix] atlantis autoplan when modules change

### DIFF
--- a/templates/atlantis/atlantis.yaml.tmpl
+++ b/templates/atlantis/atlantis.yaml.tmpl
@@ -7,7 +7,7 @@ projects:
     dir: {{ $project.Dir }}
     workflow: fogg
     autoplan:
-      when_modified: [{{ .PathToRepoRoot }}terraform/modules/*/*.tf", "*.tf*"]
+      when_modified: ["{{ .PathToRepoRoot }}terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 {{ end }}
 

--- a/templates/atlantis/atlantis.yaml.tmpl
+++ b/templates/atlantis/atlantis.yaml.tmpl
@@ -6,6 +6,9 @@ projects:
   - name: {{ $project.Name }}
     dir: {{ $project.Dir }}
     workflow: fogg
+    autoplan:
+      when_modified: [{{ .PathToRepoRoot }}modules/**/*.tf", "*.tf*"]
+      enabled: true
 {{ end }}
 
 workflows:

--- a/templates/atlantis/atlantis.yaml.tmpl
+++ b/templates/atlantis/atlantis.yaml.tmpl
@@ -7,7 +7,7 @@ projects:
     dir: {{ $project.Dir }}
     workflow: fogg
     autoplan:
-      when_modified: [{{ .PathToRepoRoot }}terraform/modules/**/*.tf", "*.tf*"]
+      when_modified: [{{ .PathToRepoRoot }}terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 {{ end }}
 

--- a/templates/atlantis/atlantis.yaml.tmpl
+++ b/templates/atlantis/atlantis.yaml.tmpl
@@ -7,7 +7,7 @@ projects:
     dir: {{ $project.Dir }}
     workflow: fogg
     autoplan:
-      when_modified: [{{ .PathToRepoRoot }}/terraform/modules/**/*.tf", "*.tf*"]
+      when_modified: [{{ .PathToRepoRoot }}terraform/modules/**/*.tf", "*.tf*"]
       enabled: true
 {{ end }}
 

--- a/templates/atlantis/atlantis.yaml.tmpl
+++ b/templates/atlantis/atlantis.yaml.tmpl
@@ -7,7 +7,7 @@ projects:
     dir: {{ $project.Dir }}
     workflow: fogg
     autoplan:
-      when_modified: [{{ .PathToRepoRoot }}modules/**/*.tf", "*.tf*"]
+      when_modified: [{{ .PathToRepoRoot }}/terraform/modules/**/*.tf", "*.tf*"]
       enabled: true
 {{ end }}
 

--- a/templates/repo/scripts/common.mk
+++ b/templates/repo/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/bless_provider/scripts/common.mk
+++ b/testdata/bless_provider/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/okta_provider/scripts/common.mk
+++ b/testdata/okta_provider/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/snowflake_provider/scripts/common.mk
+++ b/testdata/snowflake_provider/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/v1_full/scripts/common.mk
+++ b/testdata/v1_full/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/v2_full/atlantis.yaml
+++ b/testdata/v2_full/atlantis.yaml
@@ -9,30 +9,51 @@ projects:
   - name: accounts/bar
     dir: terraform/accounts/bar
     workflow: fogg
+    autoplan:
+      when_modified: [../../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
   - name: accounts/foo
     dir: terraform/accounts/foo
     workflow: fogg
+    autoplan:
+      when_modified: [../../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
   - name: global
     dir: terraform/global
     workflow: fogg
+    autoplan:
+      when_modified: [../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
   - name: staging/comp1
     dir: terraform/envs/staging/comp1
     workflow: fogg
+    autoplan:
+      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
   - name: staging/comp2
     dir: terraform/envs/staging/comp2
     workflow: fogg
+    autoplan:
+      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
   - name: staging/comp_helm_template
     dir: terraform/envs/staging/comp_helm_template
     workflow: fogg
+    autoplan:
+      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
   - name: staging/vpc
     dir: terraform/envs/staging/vpc
     workflow: fogg
+    autoplan:
+      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      enabled: true
 
 
 workflows:

--- a/testdata/v2_full/atlantis.yaml
+++ b/testdata/v2_full/atlantis.yaml
@@ -10,49 +10,49 @@ projects:
     dir: terraform/accounts/bar
     workflow: fogg
     autoplan:
-      when_modified: [../../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
   - name: accounts/foo
     dir: terraform/accounts/foo
     workflow: fogg
     autoplan:
-      when_modified: [../../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
   - name: global
     dir: terraform/global
     workflow: fogg
     autoplan:
-      when_modified: [../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
   - name: staging/comp1
     dir: terraform/envs/staging/comp1
     workflow: fogg
     autoplan:
-      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
   - name: staging/comp2
     dir: terraform/envs/staging/comp2
     workflow: fogg
     autoplan:
-      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
   - name: staging/comp_helm_template
     dir: terraform/envs/staging/comp_helm_template
     workflow: fogg
     autoplan:
-      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
   - name: staging/vpc
     dir: terraform/envs/staging/vpc
     workflow: fogg
     autoplan:
-      when_modified: [../../../../modules/**/*.tf", "*.tf*"]
+      when_modified: ["../../../../terraform/modules/*/*.tf", "*.tf*"]
       enabled: true
 
 

--- a/testdata/v2_full/scripts/common.mk
+++ b/testdata/v2_full/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/v2_minimal_valid/scripts/common.mk
+++ b/testdata/v2_minimal_valid/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 

--- a/testdata/v2_no_aws_provider/scripts/common.mk
+++ b/testdata/v2_no_aws_provider/scripts/common.mk
@@ -18,6 +18,7 @@ MODE ?= local
 
 ifeq ($(MODE),atlantis)
 	export AWS_CONFIG_FILE=$(REPO_ROOT)/config/atlantis-aws-config
+	TF_ARGS ?= -no-color
 endif
 
 


### PR DESCRIPTION
This configures auto-planning when anything in modules changes. In the future we may want to build a dependency graph between modules and components (including data dependencies), but for now the brute force approach will ensure that we don't miss changes.

### Test Plan
* CI
* ran on 1 internal repo

### References
* https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html#configuring-autoplanning
