### PR TITLE
[feature] Move terraform validate from lint stage to plan stage

### DIFF
--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -21,7 +21,7 @@ fmt: terraform
 	@echo
 .PHONY: fmt
 
-lint: terraform-validate lint-terraform-fmt lint-tflint
+lint: lint-terraform-fmt lint-tflint
 .PHONY: lint
 
 lint-tflint: init
@@ -47,10 +47,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: init fmt
+plan: terraform-validate init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: init lint
+plan: terraform-validate init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -33,10 +33,6 @@ else
 endif
 .PHONY: lint-tflint
 
-terraform-validate: terraform init
-	@$(terraform_command) validate $(TF_ARGS) -check-variables=true
-.PHONY: terraform-validate
-
 lint-terraform-fmt: terraform
 	@printf "fmt check: "
 	@for f in $(TF); do \
@@ -47,10 +43,10 @@ lint-terraform-fmt: terraform
 .PHONY: lint-terraform-fmt
 
 ifeq ($(MODE),local)
-plan: terraform-validate init fmt
+plan: init fmt
 	@$(terraform_command) plan $(TF_ARGS) -input=false
 else ifeq ($(MODE),atlantis)
-plan: terraform-validate init lint
+plan: init lint
 	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"


### PR DESCRIPTION
### Summary
Having `terraform validate` as a substep of `lint` forces us to have fully configured providers (including credentials/secrets). I would like to be able to lint code without requiring these secrets be present. One way could be moving this validation over to the plan stage (although this feels somewhat redundant).  

### Test Plan

### References