### PR TITLE
[feature] Optionally turn off refresh for plan/apply using REFRESH_ENABLED

### DIFF
--- a/templates/repo/scripts/common.mk
+++ b/templates/repo/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/bless_provider/scripts/common.mk
+++ b/testdata/bless_provider/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/okta_provider/scripts/common.mk
+++ b/testdata/okta_provider/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/snowflake_provider/scripts/common.mk
+++ b/testdata/snowflake_provider/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v1_full/scripts/common.mk
+++ b/testdata/v1_full/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v2_full/scripts/common.mk
+++ b/testdata/v2_full/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v2_minimal_valid/scripts/common.mk
+++ b/testdata/v2_minimal_valid/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v2_no_aws_provider/scripts/common.mk
+++ b/testdata/v2_no_aws_provider/scripts/common.mk
@@ -6,6 +6,8 @@ TF_VARS := $(patsubst %,-e%,$(filter TF_VAR_%,$(.VARIABLES)))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
+REFRESH_ENABLED := true # Should terraform refresh during plan/apply
+
 # We need to do this because `terraform fmt` recurses into .terraform/modules
 # and wont' accept more than one file at a time.
 TF=$(wildcard *.tf)

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -44,10 +44,10 @@ lint-terraform-fmt: terraform
 
 ifeq ($(MODE),local)
 plan: init fmt
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false
 else ifeq ($(MODE),atlantis)
 plan: init lint
-	@$(terraform_command) plan $(TF_ARGS) -refresh=false -input=false -out $(PLANFILE) | scenery
+	@$(terraform_command) plan $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -input=false -out $(PLANFILE) | scenery
 else
 	@echo "Unknown MODE: $(MODE)"
 	@exit -1
@@ -62,10 +62,10 @@ ifneq ($(FORCE),1)
 	exit -1
 endif
 endif
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=$(AUTO_APPROVE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=$(AUTO_APPROVE)
 else ifeq ($(MODE),atlantis)
 apply:
-	@$(terraform_command) apply $(TF_ARGS) -refresh=false -auto-approve=true $(PLANFILE)
+	@$(terraform_command) apply $(TF_ARGS) -refresh=$(REFRESH_ENABLED) -auto-approve=true $(PLANFILE)
 else
 	echo "Unknown mode: $(MODE)"
 	exit -1


### PR DESCRIPTION
### Summary
Fixes https://github.com/chanzuckerberg/fogg/issues/310. This turns off refresh for plan/apply. This gives us quicker plan/apply at the expense of some correctness checks.  

### Test Plan
unittests + apply in repos

### References
- https://www.terraform.io/docs/commands/refresh.html
- https://www.terraform.io/docs/commands/plan.html#refresh-true
