### PR TITLE
[fix] Read the system bff, and not a local path to bin/bff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ templates/a_templates-packr.go: $(TEMPLATES)
 packr: templates/a_templates-packr.go ## run the packr tool to generate our static files
 
 release: ## run a release
-	./bin/bff bump
+	bff bump
 	git push
 	goreleaser release
 


### PR DESCRIPTION
### Summary
The go git library does not respect nested .gitignores. Having this bin/bff is somewhat annoying at the time of release. Instead just read bff from PATH. 

### Test Plan


### References

