### PR TITLE
Use terraform-config-inspect module, add TF 0.12 input syntax support

### DIFF
--- a/exp/examine/examine.go
+++ b/exp/examine/examine.go
@@ -8,13 +8,13 @@ import (
 //TODO: Comparison between local and latest
 func Examine(fs afero.Fs, path string) error {
 	//Collect local modules to be updated
-	config, err := GetLocalModules(fs, path)
-	if err != nil && config != nil {
+	module, err := GetLocalModules(fs, path)
+	if err != nil && module != nil {
 		return err
 	}
 
 	//Load the latest version of each module
-	globalModules, err := LatestModuleVersions(fs, config)
+	globalModules, err := LatestModuleVersions(fs, module)
 	if err != nil {
 		return err
 	}

--- a/exp/examine/latest_test.go
+++ b/exp/examine/latest_test.go
@@ -14,11 +14,11 @@ func TestCompareLocalAndGlobal(t *testing.T) {
 	r.NoError(err)
 	fs := afero.NewBasePathFs(afero.NewOsFs(), pwd)
 
-	config, err := GetLocalModules(fs, "../../testdata/version_detection/terraform/envs/staging/app/")
+	module, err := GetLocalModules(fs, "../../testdata/version_detection/terraform/envs/staging/app/")
 	r.NoError(err)
-	r.NotNil(config)
+	r.NotNil(module)
 
-	globalModules, err := LatestModuleVersions(fs, config)
+	globalModules, err := LatestModuleVersions(fs, module)
 	r.NoError(err)
 	r.NotNil(globalModules)
 }
@@ -29,11 +29,11 @@ func TestCreateGitUrl(t *testing.T) {
 	r.NoError(err)
 	fs := afero.NewBasePathFs(afero.NewOsFs(), pwd)
 
-	config, err := GetLocalModules(fs, "../../testdata/version_detection/terraform/envs/staging/app/")
+	module, err := GetLocalModules(fs, "../../testdata/version_detection/terraform/envs/staging/app/")
 	r.NoError(err)
-	r.NotNil(config)
+	r.NotNil(module)
 
-	url, err := createGitUrl(config.Modules[1])
+	url, err := createGitUrl(module.ModuleCalls["parameters-policy"])
 	r.NoError(err)
 	r.NotEmpty(url)
 }

--- a/exp/examine/local.go
+++ b/exp/examine/local.go
@@ -3,7 +3,8 @@ package examine
 import (
 	"os"
 
-	"github.com/hashicorp/terraform/config"
+	"github.com/chanzuckerberg/fogg/errs"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/spf13/afero"
 )
 
@@ -15,17 +16,17 @@ const resourceType = "/modules/"
 
 //GetLocalModules retrieves all terraform modules within a given directory
 //TODO:(EC) Define local and global modules OR rename the values
-func GetLocalModules(fs afero.Fs, dir string) (*config.Config, error) {
+func GetLocalModules(fs afero.Fs, dir string) (*tfconfig.Module, error) {
 	_, err := os.Stat(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	config, err := config.LoadDir(dir)
-	if err != nil {
-		return nil, err
+	module, diag := tfconfig.LoadModule(dir)
+	if diag.HasErrors() {
+		return nil, errs.WrapInternal(diag.Err(), "There was an issue loading the module")
 	}
 
-	return config, nil
+	return module, nil
 	// return getAllModules(fs, dir)
 }

--- a/util/module_storage.go
+++ b/util/module_storage.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/chanzuckerberg/fogg/errs"
 	getter "github.com/hashicorp/go-getter"
-	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 )
@@ -66,7 +66,7 @@ func GetFoggCachePath() (string, error) {
 	return dir, nil
 }
 
-func DownloadAndParseModule(fs afero.Fs, mod string) (*config.Config, error) {
+func DownloadAndParseModule(fs afero.Fs, mod string) (*tfconfig.Module, error) {
 	dir, err := GetFoggCachePath()
 	if err != nil {
 		return nil, err
@@ -75,5 +75,9 @@ func DownloadAndParseModule(fs afero.Fs, mod string) (*config.Config, error) {
 	if err != nil {
 		return nil, errs.WrapUser(err, "unable to download module")
 	}
-	return config.LoadDir(d)
+	module, diag := tfconfig.LoadModule(d)
+	if diag.HasErrors() {
+		return nil, errs.WrapInternal(diag.Err(), "There was an issue loading the module")
+	}
+	return module, nil
 }


### PR DESCRIPTION
### Summary
Replaces uses of the internal function inside Terraform for parsing modules with a more supported separate library hashicorp/terraform-config-inspect. This library also provides support for properly parsing Terraform 0.12 HCL2 syntax. Mostly a drop in replacement, although I renamed some variables to match the new type names of the library.