### PR TITLE
[fix] hard code path to fogg in Makefile and .travis.yml

### DIFF
--- a/templates/repo/Makefile.tmpl
+++ b/templates/repo/Makefile.tmpl
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/templates/travis-ci/.travis.yml.tmpl
+++ b/templates/travis-ci/.travis.yml.tmpl
@@ -26,7 +26,7 @@ jobs:
       script:
         - |
           set -e
-          fogg apply
+          .fogg/bin/fogg apply
           if [ "$(git status --porcelain)" != "" ]; then
             echo "git tree is dirty after running fogg apply"
             echo "ensure you run fogg apply on your branch"

--- a/testdata/bless_provider/Makefile
+++ b/testdata/bless_provider/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/github_provider/Makefile
+++ b/testdata/github_provider/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/okta_provider/Makefile
+++ b/testdata/okta_provider/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/snowflake_provider/Makefile
+++ b/testdata/snowflake_provider/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/v1_full/.travis.yml
+++ b/testdata/v1_full/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       script:
         - |
           set -e
-          fogg apply
+          .fogg/bin/fogg apply
           if [ "$(git status --porcelain)" != "" ]; then
             echo "git tree is dirty after running fogg apply"
             echo "ensure you run fogg apply on your branch"

--- a/testdata/v1_full/Makefile
+++ b/testdata/v1_full/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/v2_full/Makefile
+++ b/testdata/v2_full/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/v2_minimal_valid/Makefile
+++ b/testdata/v2_minimal_valid/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/v2_no_aws_provider/Makefile
+++ b/testdata/v2_no_aws_provider/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform

--- a/testdata/version_detection/Makefile
+++ b/testdata/version_detection/Makefile
@@ -11,7 +11,7 @@ all: check
 
 setup:
 	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
-	fogg setup
+	.fogg/bin/fogg setup
 .PHONY: setup
 
 lint: lint-terraform


### PR DESCRIPTION
Fixes the issue where the fogg apply before the git --porcelain check is unable to find the fogg that was downloaded by make setup.
