### PR TITLE
Update goreleaser.yml to use brews

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,10 +23,10 @@ archives:
 release:
   prerelease: false
 
-brew:
-  description: "Terraform without pain."
-  github:
-    owner: chanzuckerberg
-    name: homebrew-tap
-  homepage: "https://github.com/chanzuckerberg/fogg"
-  test: system "#{bin}/fogg version"
+brews:
+  - description: "Terraform without pain."
+    github:
+      owner: chanzuckerberg
+      name: homebrew-tap
+    homepage: "https://github.com/chanzuckerberg/fogg"
+    test: system "#{bin}/fogg version"


### PR DESCRIPTION
### Summary
The most recent release of fogg showed a deprecation warning pointing at https://goreleaser.com/deprecations/#brew for the Goreleaser run. This PR addresses the deprecation.