### PR TITLE
[feature] Do not lock statefile during a check-plan (readonly)

### DIFF
--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/github_provider/scripts/component.mk
+++ b/testdata/github_provider/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -102,7 +102,7 @@ endif
 .PHONY: init
 
 check-plan: init check-auth
-	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode; \
+	@$(terraform_command) plan $(TF_ARGS) -detailed-exitcode -lock=false; \
 	ERR=$$?; \
 	if [ $$ERR -eq 0 ] ; then \
 		echo "Success"; \


### PR DESCRIPTION
### Summary
We've been having trouble in CI due to check-plans failing to acquire locks. Since these ops are readonly, ignoring the lock seems to be an ok compromise and not introduce any undue risk.