### PR TITLE
[fix] update to use new 0.12 syntax for variables

### DIFF
--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -53,31 +53,31 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    =  string
   default = "{{ .Project }}"
 }
 
 {{ if .Providers.AWS }}
   variable "region" {
-    type    = "string"
+    type    =  string
     default = "{{ .Providers.AWS.Region }}"
   }
 {{ end }}
 
 {{if .Providers.AWS}}
   variable "aws_profile" {
-    type = "string"
+    type =  string
     default =  "{{ .Providers.AWS.Profile }}"
   }
 {{ end }}
 
 variable "owner" {
-  type = "string"
+  type =  string
   default = "{{ .Owner }}"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type =  map
   default = {
   {{ range $account, $id := .AllAccounts }}
     {{ if $id }}
@@ -89,7 +89,7 @@ variable "aws_accounts" {
 
 {{ range $key, $val := .ExtraVars }}
 variable "{{ $key }}" {
-  type = "string"
+  type =  string
   default = "{{ $val }}"
 }
 {{ end }}

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -60,42 +60,42 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    =  string
   default = "{{ .Env }}"
 }
 
 variable "project" {
-  type    = "string"
+  type    =  string
   default = "{{ .Project }}"
 }
 
 {{if .Providers.AWS}}
   variable "region" {
-    type    = "string"
+    type    =  string
     default = "{{ .Providers.AWS.Region }}"
   }
 {{ end }}
 
 variable "component" {
-  type = "string"
+  type =  string
   default = "{{ .Component }}"
 }
 
 {{if .Providers.AWS}}
   variable "aws_profile" {
-    type = "string"
+    type =  string
     default =  "{{ .Providers.AWS.Profile }}"
   }
 {{ end }}
 
 
 variable "owner" {
-  type = "string"
+  type =  string
   default = "{{ .Owner }}"
 }
 
 variable "tags" {
-  type = "map"
+  type =  map
   default = {
     project   = "{{ .Project }}"
     env       = "{{ .Env }}"
@@ -107,7 +107,7 @@ variable "tags" {
 
 {{ range $key, $val := .ExtraVars }}
 variable "{{ $key }}" {
-  type = "string"
+  type =  string
   default = "{{ $val }}"
 }
 {{ end }}
@@ -156,7 +156,7 @@ data "terraform_remote_state" "{{ $accountName }}" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type =  map
   default = {
   {{ range $accountName, $account := .Accounts }}
     {{ if $account.Providers.AWS }}

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -58,41 +58,41 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    =  string
   default = "{{ .Env }}"
 }
 
 variable "project" {
-  type    = "string"
+  type    =  string
   default = "{{ .Project }}"
 }
 
 {{ if .Providers.AWS }}
   variable "region" {
-    type    = "string"
+    type    =  string
     default = "{{ .Providers.AWS.Region }}"
   }
 {{ end }}
 
 variable "component" {
-  type = "string"
+  type =  string
   default = "{{ .Component }}"
 }
 
 {{ if .Providers.AWS }}
   variable "aws_profile" {
-    type = "string"
+    type =  string
     default =  "{{ .Providers.AWS.Profile }}"
   }
 {{ end }}
 
 variable "owner" {
-  type = "string"
+  type =  string
   default = "{{ .Owner }}"
 }
 
 variable "tags" {
-  type = "map"
+  type =  map
   default = {
     project   = "{{ .Project }}"
     env       = "{{ .Env }}"
@@ -104,7 +104,7 @@ variable "tags" {
 
 {{ range $key, $val := .ExtraVars }}
 variable "{{ $key }}" {
-  type = "string"
+  type =  string
   default = "{{ $val }}"
 }
 {{ end }}

--- a/testdata/bless_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider/terraform/accounts/foo/fogg.tf
@@ -50,7 +50,7 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foofoo"
 }
 
@@ -59,12 +59,12 @@ variable "project" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -53,19 +53,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "bar"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foofoo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "bam"
 }
 
@@ -73,12 +73,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foofoo"
     env       = "bar"
@@ -122,7 +122,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/bless_provider/terraform/global/fogg.tf
+++ b/testdata/bless_provider/terraform/global/fogg.tf
@@ -52,31 +52,31 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foofoo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foofoo"
     env       = ""

--- a/testdata/github_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider/terraform/accounts/foo/fogg.tf
@@ -34,7 +34,7 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
@@ -43,12 +43,12 @@ variable "project" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -37,19 +37,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "bar"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "bam"
 }
 
@@ -57,12 +57,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foo"
     env       = "bar"
@@ -106,7 +106,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/github_provider/terraform/global/fogg.tf
+++ b/testdata/github_provider/terraform/global/fogg.tf
@@ -36,31 +36,31 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/okta_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider/terraform/accounts/foo/fogg.tf
@@ -34,7 +34,7 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foofoo"
 }
 
@@ -43,12 +43,12 @@ variable "project" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -37,19 +37,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "bar"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foofoo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "bam"
 }
 
@@ -57,12 +57,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foofoo"
     env       = "bar"
@@ -106,7 +106,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/okta_provider/terraform/global/fogg.tf
+++ b/testdata/okta_provider/terraform/global/fogg.tf
@@ -36,31 +36,31 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foofoo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foofoo"
     env       = ""

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -35,7 +35,7 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
@@ -44,12 +44,12 @@ variable "project" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -38,19 +38,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "bar"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "bam"
 }
 
@@ -58,12 +58,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foo"
     env       = "bar"
@@ -107,7 +107,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/snowflake_provider/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider/terraform/global/fogg.tf
@@ -37,31 +37,31 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -44,31 +44,31 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "bar-project"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-bar1"
 }
 
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "czi-bar"
 }
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "bar@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 
@@ -84,7 +84,7 @@ variable "aws_accounts" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar"
 }
 

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -44,31 +44,31 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo-project"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-foo1"
 }
 
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "czi-foo"
 }
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 
@@ -84,7 +84,7 @@ variable "aws_accounts" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -48,42 +48,42 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "stage"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "env-project"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-env1"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "cloud-env"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "czi-env"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "env@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "env-project"
     env       = "stage"
@@ -95,7 +95,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "env"
 }
 
@@ -156,7 +156,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -48,42 +48,42 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "stage"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "stage-project"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-stage1"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "helm"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "czi-stage"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "stage@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "stage-project"
     env       = "stage"
@@ -95,7 +95,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "stage"
 }
 
@@ -156,7 +156,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v1_full/terraform/global/fogg.tf
+++ b/testdata/v1_full/terraform/global/fogg.tf
@@ -46,41 +46,41 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "test-project"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-1"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "czi"
 }
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "default@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "test-project"
     env       = ""
@@ -92,7 +92,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar"
 }
 

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -36,31 +36,31 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-2"
 }
 
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "profile"
 }
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 
@@ -76,7 +76,7 @@ variable "aws_accounts" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar1"
 }
 

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -36,31 +36,31 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-2"
 }
 
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "profile"
 }
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 
@@ -76,7 +76,7 @@ variable "aws_accounts" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar1"
 }
 

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -40,42 +40,42 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "staging"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-2"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "comp1"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "profile"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = "staging"
@@ -87,7 +87,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar2"
 }
 
@@ -160,7 +160,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -40,42 +40,42 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "staging"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-2"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "comp2"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "profile"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = "staging"
@@ -87,7 +87,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar2"
 }
 
@@ -160,7 +160,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -40,42 +40,42 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "staging"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-2"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "vpc"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "profile"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = "staging"
@@ -87,7 +87,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar3"
 }
 
@@ -160,7 +160,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v2_full/terraform/global/fogg.tf
+++ b/testdata/v2_full/terraform/global/fogg.tf
@@ -38,41 +38,41 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "us-west-2"
 }
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 variable "aws_profile" {
-  type    = "string"
+  type    = string
   default = "profile"
 }
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = ""
@@ -84,7 +84,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar1"
 }
 

--- a/testdata/v2_minimal_valid/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid/terraform/global/fogg.tf
@@ -27,31 +27,31 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "foo"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -25,7 +25,7 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
@@ -34,12 +34,12 @@ variable "project" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 
@@ -51,7 +51,7 @@ variable "aws_accounts" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar1"
 }
 

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -25,7 +25,7 @@ terraform {
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
@@ -34,12 +34,12 @@ variable "project" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 
@@ -51,7 +51,7 @@ variable "aws_accounts" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar1"
 }
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -28,19 +28,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "staging"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "comp1"
 }
 
@@ -48,12 +48,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = "staging"
@@ -65,7 +65,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar2"
 }
 
@@ -138,7 +138,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -28,19 +28,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "staging"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "comp2"
 }
 
@@ -48,12 +48,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = "staging"
@@ -65,7 +65,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar2"
 }
 
@@ -138,7 +138,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -28,19 +28,19 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = "staging"
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "vpc"
 }
 
@@ -48,12 +48,12 @@ variable "component" {
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = "staging"
@@ -65,7 +65,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar3"
 }
 
@@ -138,7 +138,7 @@ data "terraform_remote_state" "foo" {
 
 # map of aws_accounts
 variable "aws_accounts" {
-  type = "map"
+  type = map
   default = {
 
 

--- a/testdata/v2_no_aws_provider/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/global/fogg.tf
@@ -27,31 +27,31 @@ terraform {
 }
 
 variable "env" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "project" {
-  type    = "string"
+  type    = string
   default = "proj"
 }
 
 
 
 variable "component" {
-  type    = "string"
+  type    = string
   default = "global"
 }
 
 
 
 variable "owner" {
-  type    = "string"
+  type    = string
   default = "foo@example.com"
 }
 
 variable "tags" {
-  type = "map"
+  type = map
   default = {
     project   = "proj"
     env       = ""
@@ -63,7 +63,7 @@ variable "tags" {
 
 
 variable "foo" {
-  type    = "string"
+  type    = string
   default = "bar1"
 }
 


### PR DESCRIPTION
As of terraform 0.12.14, quotes around the type in a variable are deprecated, so we should stop producing code that has quotes around the type.

### Test Plan
* unit test so far
* built a prerelease and ran it against 1 repo

### References
* https://github.com/hashicorp/terraform/releases/tag/v0.12.14