### PR TITLE
[fix] ensure we always download the right version of fogg

### DIFF
--- a/templates/repo/Makefile.tmpl
+++ b/templates/repo/Makefile.tmpl
@@ -10,7 +10,7 @@ ACCOUNTS={{ .Accounts | dict | keys | sortAlpha | join " "}}
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin {{.Version}}
 	.fogg/bin/fogg setup
 .PHONY: setup
 

--- a/testdata/bless_provider/Makefile
+++ b/testdata/bless_provider/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/github_provider/Makefile
+++ b/testdata/github_provider/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/okta_provider/Makefile
+++ b/testdata/okta_provider/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/snowflake_provider/Makefile
+++ b/testdata/snowflake_provider/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v1_full/Makefile
+++ b/testdata/v1_full/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=bar foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/Makefile
+++ b/testdata/v2_full/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=bar foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_minimal_valid/Makefile
+++ b/testdata/v2_minimal_valid/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/Makefile
+++ b/testdata/v2_no_aws_provider/Makefile
@@ -10,7 +10,7 @@ ACCOUNTS=bar foo
 all: check
 
 setup: ## set up working directory by installing dependencies
-	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin $(FOGG_VERSION)
+	curl -s https://raw.githubusercontent.com/chanzuckerberg/fogg/master/download.sh | bash -s -- -b .fogg/bin undefined+undefined+dirty
 	.fogg/bin/fogg setup
 .PHONY: setup
 
@@ -143,3 +143,4 @@ clean-global: ## clean in terraform/global
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+


### PR DESCRIPTION
I am somewhat surprised that this hasn't been causing us trouble.

### Test Plan
* unit tests

### References

