### PR TITLE
simplify `make fmt`

### DIFF
--- a/templates/repo/scripts/common.mk
+++ b/templates/repo/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/bless_provider/scripts/common.mk
+++ b/testdata/bless_provider/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/github_provider/scripts/common.mk
+++ b/testdata/github_provider/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/github_provider/scripts/component.mk
+++ b/testdata/github_provider/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/okta_provider/scripts/common.mk
+++ b/testdata/okta_provider/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/snowflake_provider/scripts/common.mk
+++ b/testdata/snowflake_provider/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/v1_full/scripts/common.mk
+++ b/testdata/v1_full/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/v2_full/scripts/common.mk
+++ b/testdata/v2_full/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/v2_minimal_valid/scripts/common.mk
+++ b/testdata/v2_minimal_valid/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component

--- a/testdata/v2_no_aws_provider/scripts/common.mk
+++ b/testdata/v2_no_aws_provider/scripts/common.mk
@@ -8,10 +8,6 @@ REPO_RELATIVE_PATH := $(shell git rev-parse --show-prefix)
 AUTO_APPROVE := false
 REFRESH_ENABLED ?= true # Should terraform refresh during plan/apply
 
-# We need to do this because `terraform fmt` recurses into .terraform/modules
-# and wont' accept more than one file at a time.
-TF=$(wildcard *.tf)
-
 TFENV_DIR ?= $(REPO_ROOT)/.fogg/tfenv
 export PATH :=$(TFENV_DIR)/libexec:$(TFENV_DIR)/versions/$(TERRAFORM_VERSION)/:$(REPO_ROOT)/.fogg/bin:$(PATH)
 export TF_PLUGIN_CACHE_DIR=$(REPO_ROOT)/.terraform.d/plugin-cache

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -17,9 +17,7 @@ check: lint check-plan ## run all checks for this component
 .PHONY: check
 
 fmt: terraform ## format code in this component
-	@printf "fmt: ";
-	@for f in $(TF); do printf .; $(terraform_command) fmt $(TF_ARGS) $$f; done
-	@echo
+	$(terraform_command) fmt $(TF_ARGS)
 .PHONY: fmt
 
 lint: lint-terraform-fmt lint-tflint ## run all linters for this component


### PR DESCRIPTION
Previously `terraform fmt` would always recurse into nested directories,
including .terraform. This caused two problems–

1. `terraform fmt` would try to reformat modules which had been init'ed.
    Beacause these modules are just git checkouts later updates to those
    modules would fail due to uncommited changes in those working dirs.
2. `terraform fmt -check`, run via `make lint` would fail if modules in-updates
    had format errors.

To work around this, we did a non-recursive list of terraform files and
called `terraform fmt` for each one, which is somewhat slower.

Now `terraform fmt` *does not* recurse by default, so we can remove our
workaround.

### Summary
A description of changes or issues addressed by this PR. Provide links to relevant PRs if any.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
