### PR TITLE
output component name & suppress tfenv command

### DIFF
--- a/templates/env/Makefile.tmpl
+++ b/templates/env/Makefile.tmpl
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/templates/repo/scripts/common.mk
+++ b/templates/repo/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/bless_provider/scripts/common.mk
+++ b/testdata/bless_provider/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/bless_provider/terraform/envs/bar/Makefile
+++ b/testdata/bless_provider/terraform/envs/bar/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/github_provider/scripts/common.mk
+++ b/testdata/github_provider/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/github_provider/terraform/envs/bar/Makefile
+++ b/testdata/github_provider/terraform/envs/bar/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/okta_provider/scripts/common.mk
+++ b/testdata/okta_provider/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/okta_provider/terraform/envs/bar/Makefile
+++ b/testdata/okta_provider/terraform/envs/bar/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/snowflake_provider/scripts/common.mk
+++ b/testdata/snowflake_provider/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/snowflake_provider/terraform/envs/bar/Makefile
+++ b/testdata/snowflake_provider/terraform/envs/bar/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/v1_full/scripts/common.mk
+++ b/testdata/v1_full/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/v1_full/terraform/envs/stage/Makefile
+++ b/testdata/v1_full/terraform/envs/stage/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/v2_full/scripts/common.mk
+++ b/testdata/v2_full/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/v2_full/terraform/envs/prod/Makefile
+++ b/testdata/v2_full/terraform/envs/prod/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/v2_full/terraform/envs/staging/Makefile
+++ b/testdata/v2_full/terraform/envs/staging/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/v2_minimal_valid/scripts/common.mk
+++ b/testdata/v2_minimal_valid/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/v2_no_aws_provider/scripts/common.mk
+++ b/testdata/v2_no_aws_provider/scripts/common.mk
@@ -28,5 +28,5 @@ tfenv: ## install the tfenv tool
 .PHONY: tfenv
 
 terraform: tfenv ## ensure that the proper version of terraform is installed
-	${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
+	@${TFENV_DIR}/bin/tfenv install $(TERRAFORM_VERSION)
 .PHONY: terraform

--- a/testdata/v2_no_aws_provider/terraform/envs/prod/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/envs/prod/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/Makefile
@@ -8,30 +8,35 @@ all:
 
 lint: ## lint all components in the env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c lint || exit $$? ; \
 	done
 .PHONY: lint
 
 fmt: ## format terraform code in all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c fmt || exit $$? ; \
 	done
 .PHONY: fmt
 
 check-plan: ## check all plans in this environment
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c check-plan || exit $$? ; \
 	done
 .PHONY: check-plan
 
 docs: ## generate docs for all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c docs || exit $$? ; \
 	done
 .PHONY: docs
 
 clean: ## clean all components in this env
 	@for c in $(COMPONENTS); do \
+		echo $$c; \
 		$(MAKE) -C $$c clean || exit $$? ; \
 	done
 .PHONY: clean


### PR DESCRIPTION
Two small changes to clean up the output when running make targets.

1. When commands across a bunch of components at once, it helps to print
   out the component name before we run each one.
2. suppress the command output for the `tfenv install`

### Test Plan
* unit tests

### References

