### PR TITLE
[feature] heroku provider

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -147,8 +147,7 @@ type SnowflakeProvider struct {
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
-type HerokuProvider struct {
-}
+type HerokuProvider struct{}
 
 type Backend struct {
 	AccountID   *string `json:"account_id,omitempty" yaml:"account_id,omitempty"`

--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -104,6 +104,7 @@ type Providers struct {
 	AWS       *AWSProvider       `json:"aws,omitempty" yaml:"aws,omitempty"`
 	Bless     *BlessProvider     `json:"bless,omitempty" yaml:"bless,omitempty"`
 	Github    *GithubProvider    `json:"github,omitempty" yaml:"github,omitempty"`
+	Heroku    *HerokuProvider    `json:"heroku,omitempty" yaml:"heroku,omitempty"`
 	Okta      *OktaProvider      `json:"okta,omitempty" yaml:"okta,omitempty"`
 	Snowflake *SnowflakeProvider `json:"snowflake,omitempty" yaml:"snowflake,omitempty"`
 }
@@ -144,6 +145,9 @@ type SnowflakeProvider struct {
 	Role    *string `json:"role,omitempty" yaml:"role,omitempty"`
 	Region  *string `json:"region,omitempty" yaml:"region,omitempty"`
 	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
+type HerokuProvider struct {
 }
 
 type Backend struct {
@@ -246,6 +250,13 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 		return nil
 	}
 
+	randHerokuProvider := func(r *rand.Rand, s int) *HerokuProvider {
+		if r.Float32() < 0.5 {
+			return &HerokuProvider{}
+		}
+		return nil
+	}
+
 	randCommon := func(r *rand.Rand, s int) Common {
 		c := Common{
 			Backend: &Backend{
@@ -260,6 +271,7 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 				Snowflake: randSnowflakeProvider(r, s),
 				Okta:      randOktaProvider(r, s),
 				Bless:     randBlessProvider(r, s),
+				Heroku:    randHerokuProvider(r, s),
 			},
 			TerraformVersion: randStringPtr(r, s),
 		}

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -181,6 +181,18 @@ func ResolveBlessProvider(commons ...Common) *BlessProvider {
 	}
 }
 
+func ResolveHerokuProvider(commons ...Common) *HerokuProvider {
+	var p *HerokuProvider
+	for _, c := range commons {
+		if c.Providers == nil || c.Providers.Heroku == nil {
+			continue
+		}
+		p = c.Providers.Heroku
+	}
+
+	return p
+}
+
 func ResolveTfLint(commons ...Common) v1.TfLint {
 	enabled := false
 	for _, c := range commons {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -115,6 +115,7 @@ func (c CIComponent) generateCIConfig(
 type Providers struct {
 	AWS       *AWSProvider       `yaml:"aws"`
 	Github    *GithubProvider    `yaml:"github"`
+	Heroku    *HerokuProvider    `yaml:"heroku"`
 	Snowflake *SnowflakeProvider `yaml:"snowflake"`
 	Bless     *BlessProvider     `yaml:"bless"`
 	Okta      *OktaProvider      `yaml:"okta"`
@@ -157,6 +158,8 @@ type BlessProvider struct {
 	AWSRegion         string   `json:"aws_region,omitempty" yaml:"aws_region,omitempty"`
 	Version           *string  `json:"version,omitempty" yaml:"version,omitempty"`
 }
+
+type HerokuProvider struct{}
 
 // AWSBackend represents aws backend configuration
 type AWSBackend struct {
@@ -397,6 +400,12 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		}
 	}
 
+	var herokuPlan *HerokuProvider
+	herokuConfig := v2.ResolveHerokuProvider(commons...)
+	if herokuConfig != nil {
+		herokuPlan = &HerokuProvider{}
+	}
+
 	tflintConfig := v2.ResolveTfLint(commons...)
 
 	tfLintPlan := TfLint{
@@ -453,6 +462,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		Providers: Providers{
 			AWS:       awsPlan,
 			Github:    githubPlan,
+			Heroku:    herokuPlan,
 			Snowflake: snowflakePlan,
 			Bless:     blessPlan,
 			Okta:      oktaPlan,

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -196,6 +196,11 @@ func TestPlanBasicV2Yaml(t *testing.T) {
 
 	assert.NotNil(t, plan.Envs["staging"].Components["comp_helm_template"])
 	assert.Equal(t, "k8s", plan.Envs["staging"].Components["comp_helm_template"].EKS.ClusterName)
+
+	assert.NotNil(t, plan.Envs["prod"])
+	assert.NotNil(t, plan.Envs["prod"].Components["hero"])
+	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers)
+	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers.Heroku)
 }
 
 func TestExtraVarsCompositionV2(t *testing.T) {

--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -39,6 +39,10 @@
   {{ template "github_provider" .Providers.Github}}
 {{ end }}
 
+{{ if .Providers.Heroku }}
+  {{ template "heroku_provider" .Providers.Heroku }}
+{{ end }}
+
 terraform {
   required_version = "={{ .TerraformVersion }}"
 

--- a/templates/common/heroku_provider.tmpl
+++ b/templates/common/heroku_provider.tmpl
@@ -1,0 +1,4 @@
+{{define "heroku_provider"}}
+provider "heroku" {
+}
+{{ end }}

--- a/templates/component/terraform/Makefile.tmpl
+++ b/templates/component/terraform/Makefile.tmpl
@@ -8,6 +8,9 @@ export AWS_BACKEND_PROFILE := {{ .Backend.Profile }}
 {{if .Providers.AWS}}
 export AWS_PROVIDER_PROFILE := {{ .Providers.AWS.Profile }}
 {{ end }}
+{{if .Providers.Heroku}}
+export HEROKU_PROVIDER := 1
+{{end}}
 
 include {{ .PathToRepoRoot }}/scripts/component.mk
 

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -39,6 +39,10 @@
   {{ template "github_provider" .Providers.Github}}
 {{ end }}
 
+{{ if .Providers.Heroku }}
+  {{ template "heroku_provider" .Providers.Heroku }}
+{{ end }}
+
 terraform {
   required_version = "~>{{ .TerraformVersion }}"
 

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -38,6 +38,11 @@
   {{ template "github_provider" .Providers.Github}}
 {{ end }}
 
+{{ if .Providers.Heroku }}
+  {{ template "heroku_provider" .Providers.Heroku }}
+{{ end }}
+
+
 terraform {
   required_version = "~>{{ .TerraformVersion }}"
 

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -52,7 +52,11 @@ check-auth-aws:
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/templates/repo/scripts/component.mk
+++ b/templates/repo/scripts/component.mk
@@ -51,12 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
 	@if command heroku >/dev/null; then \
 		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
 	else \
 		echo "Heroku CLI not installed, can't check auth."; \
 	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -21,7 +21,7 @@ func TestOpenTemplate(t *testing.T) {
 		tLen    int
 		wantErr bool
 	}{
-		{"foo", args{temps.Account, "Makefile.tmpl"}, 7, false},
+		{"foo", args{temps.Account, "Makefile.tmpl"}, 8, false},
 	}
 
 	for _, tt := range tests {

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/bless_provider/scripts/component.mk
+++ b/testdata/bless_provider/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/bless_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider/terraform/accounts/foo/fogg.tf
@@ -36,6 +36,8 @@ provider "bless" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/bless_provider/terraform/envs/bar/bam/Makefile
+++ b/testdata/bless_provider/terraform/envs/bar/bam/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := foofoo
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -36,6 +36,8 @@ provider "bless" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/bless_provider/terraform/global/fogg.tf
+++ b/testdata/bless_provider/terraform/global/fogg.tf
@@ -36,6 +36,9 @@ provider "bless" {
 
 
 
+
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/github_provider/scripts/component.mk
+++ b/testdata/github_provider/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/github_provider/scripts/component.mk
+++ b/testdata/github_provider/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/github_provider/scripts/component.mk
+++ b/testdata/github_provider/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/github_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider/terraform/accounts/foo/fogg.tf
@@ -20,6 +20,8 @@ provider "github" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/github_provider/terraform/envs/bar/bam/Makefile
+++ b/testdata/github_provider/terraform/envs/bar/bam/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := foo
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -20,6 +20,8 @@ provider "github" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/github_provider/terraform/global/fogg.tf
+++ b/testdata/github_provider/terraform/global/fogg.tf
@@ -20,6 +20,9 @@ provider "github" {
 
 
 
+
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/okta_provider/scripts/component.mk
+++ b/testdata/okta_provider/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/okta_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider/terraform/accounts/foo/fogg.tf
@@ -20,6 +20,8 @@ provider "okta" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/okta_provider/terraform/envs/bar/bam/Makefile
+++ b/testdata/okta_provider/terraform/envs/bar/bam/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := foofoo
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -20,6 +20,8 @@ provider "okta" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/okta_provider/terraform/global/fogg.tf
+++ b/testdata/okta_provider/terraform/global/fogg.tf
@@ -20,6 +20,9 @@ provider "okta" {
 
 
 
+
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/snowflake_provider/scripts/component.mk
+++ b/testdata/snowflake_provider/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -21,6 +21,8 @@ provider "snowflake" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/Makefile
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := foo
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -21,6 +21,8 @@ provider "snowflake" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/snowflake_provider/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider/terraform/global/fogg.tf
@@ -21,6 +21,9 @@ provider "snowflake" {
 
 
 
+
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v1_full/scripts/component.mk
+++ b/testdata/v1_full/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -30,6 +30,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.13.0"
 

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -30,6 +30,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.12.0"
 

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/Makefile
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/Makefile
@@ -9,9 +9,11 @@ export AWS_BACKEND_PROFILE := czi-env
 export AWS_PROVIDER_PROFILE := czi-env
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -31,6 +31,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.15.0"
 

--- a/testdata/v1_full/terraform/envs/stage/helm/Makefile
+++ b/testdata/v1_full/terraform/envs/stage/helm/Makefile
@@ -9,9 +9,11 @@ export AWS_BACKEND_PROFILE := czi-stage
 export AWS_PROVIDER_PROFILE := czi-stage
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -31,6 +31,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.14.0"
 

--- a/testdata/v1_full/terraform/global/fogg.tf
+++ b/testdata/v1_full/terraform/global/fogg.tf
@@ -30,6 +30,9 @@ provider "aws" {
 
 
 
+
+
+
 terraform {
   required_version = "~>0.11.0"
 

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v2_full/scripts/component.mk
+++ b/testdata/v2_full/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -22,6 +22,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -22,6 +22,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_full/terraform/envs/staging/comp1/Makefile
+++ b/testdata/v2_full/terraform/envs/staging/comp1/Makefile
@@ -9,9 +9,11 @@ export AWS_BACKEND_PROFILE := comp1
 export AWS_PROVIDER_PROFILE := profile
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -23,6 +23,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full/terraform/envs/staging/comp2/Makefile
+++ b/testdata/v2_full/terraform/envs/staging/comp2/Makefile
@@ -9,9 +9,11 @@ export AWS_BACKEND_PROFILE := profile
 export AWS_PROVIDER_PROFILE := profile
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -23,6 +23,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full/terraform/envs/staging/vpc/Makefile
+++ b/testdata/v2_full/terraform/envs/staging/vpc/Makefile
@@ -9,9 +9,11 @@ export AWS_BACKEND_PROFILE := profile
 export AWS_PROVIDER_PROFILE := profile
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -23,6 +23,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full/terraform/global/fogg.tf
+++ b/testdata/v2_full/terraform/global/fogg.tf
@@ -22,6 +22,9 @@ provider "aws" {
 
 
 
+
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full_yaml/fogg.yml
+++ b/testdata/v2_full_yaml/fogg.yml
@@ -24,7 +24,11 @@ defaults:
       version: 0.12.0
   terraform_version: 0.100.0
 envs:
-  prod: {}
+  prod:
+    components:
+      hero:
+        providers:
+          heroku: {}
   staging:
     components:
       comp_helm_template:

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v2_minimal_valid/scripts/component.mk
+++ b/testdata/v2_minimal_valid/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/v2_minimal_valid/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid/terraform/global/fogg.tf
@@ -11,6 +11,9 @@
 
 
 
+
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -41,18 +41,18 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: check-auth-aws ## check that authentication is properly set up for this component
+check-auth: check-auth-aws check-auth-heroku ## check that authentication is properly set up for this component
 .PHONY: check-auth
 
 check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
-		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
+		aws --profile $$p sts get-caller-identity > /dev/null || (echo "AWS AUTH error. This component is configured to use a profile named '$$p'. Please add one to your ~/.aws/config" && exit -1); \
 	done
 .PHONY: check-auth-aws
 
 check-auth-heroku:
 	@echo "Checking heroku auth..."
-	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -51,8 +51,14 @@ check-auth-aws:
 .PHONY: check-auth-aws
 
 check-auth-heroku:
+ifeq ($(HEROKU_PROVIDER),1)
 	@echo "Checking heroku auth..."
-	@heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1);
+	@if command heroku >/dev/null; then \
+		heroku auth:whoami || (echo "Not authenticated to heroku. For SSO accounts, run 'heroku login', for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY" && exit -1); \
+	else \
+		echo "Heroku CLI not installed, can't check auth."; \
+	fi
+endif
 .PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)

--- a/testdata/v2_no_aws_provider/scripts/component.mk
+++ b/testdata/v2_no_aws_provider/scripts/component.mk
@@ -41,11 +41,19 @@ lint-terraform-fmt: terraform ## run `terraform fmt` in check mode
 	@echo
 .PHONY: lint-terraform-fmt
 
-check-auth: ## check that authentication is properly set up for this component
+check-auth: check-auth-aws ## check that authentication is properly set up for this component
+.PHONY: check-auth
+
+check-auth-aws:
 	@for p in $(AWS_BACKEND_PROFILE) $(AWS_PROVIDER_PROFILE); do \
 		aws --profile $$p sts get-caller-identity > /dev/null || echo "AWS AUTH error. This component is configured to use a profile name $$p. Please add one to your ~/.aws/config"; \
 	done
-.PHONY: check-auth
+.PHONY: check-auth-aws
+
+check-auth-heroku:
+	@echo "Checking heroku auth..."
+	heroku auth:whoami || echo "Not authenticated to heroku. For sso accounts, run `heroku login`, for non-sso accounts set HEROKU_EMAIL and HEROKU_API_KEY"
+.PHONY: check-auth-heroku
 
 ifeq ($(MODE),local)
 plan: check-auth init fmt ## run a terraform plan

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -11,6 +11,8 @@
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -11,6 +11,8 @@
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := profile
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -11,6 +11,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := profile
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -11,6 +11,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/Makefile
@@ -7,9 +7,11 @@ export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export AWS_BACKEND_PROFILE := profile
 
 
+
 include ../../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -11,6 +11,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/global/fogg.tf
@@ -11,6 +11,9 @@
 
 
 
+
+
+
 terraform {
   required_version = "~>0.100.0"
 


### PR DESCRIPTION
This PR enables using fogg to generate heroku provider configurations.

The configuration is pretty simple, because [the heroku provider](https://www.terraform.io/docs/providers/heroku/) doesn't take many relevant options.

In the process of working on this I discovered that if you use `heroku login` to auth to an sso account, the terraform provider "Just Works".

It currently has a few limitations–

1. It cannot pin versions. I will follow up with a PR to add that soon.
2. Checking auth requires having the heroku cli installed. Because that cli is built on node it is hard for us to automated downloading and installing it, meaning that users will have to do so out-of-band.

### Test Plan
* unit tests
* did some manual tests with one of our internal repos that already uses the heroku provider

### References
* 
