### PR TITLE
[feature] pin more provider versions

### DIFF
--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -126,3 +126,15 @@ data "terraform_remote_state" "{{ $accountName }}" {
 }
 {{ end }}
 {{ end }}
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -165,3 +165,11 @@ variable "aws_accounts" {
   {{ end }}
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -173,3 +173,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -128,3 +128,15 @@ data "terraform_remote_state" "{{ $component }}" {
   }
 }
 {{ end }}
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/bless_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider/terraform/accounts/foo/fogg.tf
@@ -92,3 +92,15 @@ data "terraform_remote_state" "global" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -137,3 +137,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -129,3 +129,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/bless_provider/terraform/global/fogg.tf
+++ b/testdata/bless_provider/terraform/global/fogg.tf
@@ -93,3 +93,15 @@ variable "tags" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/github_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider/terraform/accounts/foo/fogg.tf
@@ -76,3 +76,15 @@ data "terraform_remote_state" "global" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -113,3 +113,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -121,3 +121,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/github_provider/terraform/global/fogg.tf
+++ b/testdata/github_provider/terraform/global/fogg.tf
@@ -77,3 +77,15 @@ variable "tags" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/okta_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider/terraform/accounts/foo/fogg.tf
@@ -76,3 +76,15 @@ data "terraform_remote_state" "global" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -113,3 +113,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -121,3 +121,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/okta_provider/terraform/global/fogg.tf
+++ b/testdata/okta_provider/terraform/global/fogg.tf
@@ -77,3 +77,15 @@ variable "tags" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -77,3 +77,15 @@ data "terraform_remote_state" "global" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -114,3 +114,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -122,3 +122,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/snowflake_provider/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider/terraform/global/fogg.tf
@@ -78,3 +78,15 @@ variable "tags" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -121,3 +121,15 @@ data "terraform_remote_state" "foo" {
 }
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -121,3 +121,15 @@ data "terraform_remote_state" "bar" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -169,3 +169,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -177,3 +177,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -169,3 +169,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -177,3 +177,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v1_full/terraform/global/fogg.tf
+++ b/testdata/v1_full/terraform/global/fogg.tf
@@ -102,3 +102,15 @@ variable "foo" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -113,3 +113,15 @@ data "terraform_remote_state" "foo" {
 }
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -113,3 +113,15 @@ data "terraform_remote_state" "bar" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -173,3 +173,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -181,3 +181,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -173,3 +173,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -181,3 +181,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -173,3 +173,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -181,3 +181,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_full/terraform/global/fogg.tf
+++ b/testdata/v2_full/terraform/global/fogg.tf
@@ -94,3 +94,15 @@ variable "foo" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_minimal_valid/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid/terraform/global/fogg.tf
@@ -68,3 +68,15 @@ variable "tags" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -88,3 +88,15 @@ data "terraform_remote_state" "foo" {
 }
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -88,3 +88,15 @@ data "terraform_remote_state" "bar" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -147,3 +147,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -155,3 +155,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -147,3 +147,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -155,3 +155,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -147,3 +147,11 @@ variable "aws_accounts" {
 
   }
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -155,3 +155,7 @@ provider random {
 provider template {
   version = "~> 2.1"
 }
+
+provider archive {
+  version = "~> 1.3"
+}

--- a/testdata/v2_no_aws_provider/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/global/fogg.tf
@@ -73,3 +73,15 @@ variable "foo" {
 
 
 
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}


### PR DESCRIPTION
This pins the versions the [random](https://www.terraform.io/docs/providers/random/index.html), [template](https://www.terraform.io/docs/providers/template/index.html) and [archive](https://www.terraform.io/docs/providers/archive/index.html) providers.

These providers are often used and have a low release velocity, so for now we will hard-code them into fogg. If and when they are releasing new versions we can update the hard-coded configurations for allow the versions to be configurable via fogg.yml.

### Test Plan
* unit tests

### References
* https://www.terraform.io/docs/providers/random/index.html
* https://www.terraform.io/docs/providers/template/index.html
* https://www.terraform.io/docs/providers/archive/index.html