### PR TITLE
[feature] aws cred_process redirects stderr to /dev/tty such that users can see mfa prompts

### DIFF
--- a/cmd/exp/aws_config.go
+++ b/cmd/exp/aws_config.go
@@ -116,6 +116,12 @@ var awsConfigCmd = &cobra.Command{
 				oktaSection.Key("role_arn").SetValue(roleARN.String())
 				oktaSection.Key("aws_saml_url").SetValue(*oktaAwsSamlURL)
 
+				// HACK HACK (el): botocore will consume both stderr and stdout
+				// we need a way to display mfa prompts to users
+				// direct stderr to the tty directly.
+				// I assume there are some corner cases where this might break
+				// but seems like a good enough place to start.
+				// https://github.com/boto/botocore/issues/1348
 				section.Key("credential_process").SetValue(
 					fmt.Sprintf("sh -c 'aws-okta cred-process %s --mfa-duo-device %s 2> /dev/tty'", oktaProfileName, *awsOktaMFADevice))
 			}

--- a/cmd/exp/aws_config.go
+++ b/cmd/exp/aws_config.go
@@ -117,7 +117,7 @@ var awsConfigCmd = &cobra.Command{
 				oktaSection.Key("aws_saml_url").SetValue(*oktaAwsSamlURL)
 
 				section.Key("credential_process").SetValue(
-					fmt.Sprintf("aws-okta cred-process %s --mfa-duo-device %s", oktaProfileName, *awsOktaMFADevice))
+					fmt.Sprintf("sh -c 'aws-okta cred-process %s --mfa-duo-device %s 2> /dev/tty'", oktaProfileName, *awsOktaMFADevice))
 			}
 		}
 		awsConfigFile, err := os.OpenFile(awsConfigPath, os.O_WRONLY|os.O_CREATE, 0600)


### PR DESCRIPTION
### Summary
botocore will consume both stderr and stdout for their cred_process. We use this hack to make sure that stderr is displayed back to the user. stdout is still consumed by botocore as normal.

### Test Plan
```
aws sts get-caller-identity --profile XXXXXX
INFO[0001] Requesting MFA. Please complete two-factor authentication with your second device             
INFO[0002] Device: XXXXXXX                               
{
    "Account": "XXXXXXXX", 
    "UserId": "XXXXXX", 
    "Arn": "arn:aws:sts::XXXX:assumed-role/XXXX/XXXX"
}
```


### References
https://github.com/boto/botocore/issues/1348
