### PR TITLE
[fix] Create directories in aws config path file if they doesn't exis…

### DIFF
--- a/cmd/exp/aws_config.go
+++ b/cmd/exp/aws_config.go
@@ -126,6 +126,16 @@ var awsConfigCmd = &cobra.Command{
 					fmt.Sprintf("sh -c 'aws-okta cred-process %s --mfa-duo-device %s 2> /dev/tty'", oktaProfileName, *awsOktaMFADevice))
 			}
 		}
+
+		// Create directories in the aws config path if they doesn't exist already.
+		dirName := filepath.Dir(fileName)
+		if _, err := os.Stat(dirName); err != nil {
+			err := os.MkdirAll(dirName, os.ModePerm)
+			if err != nil {
+				return err
+			}
+		}
+
 		awsConfigFile, err := os.OpenFile(awsConfigPath, os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {
 			return err

--- a/cmd/exp/aws_config.go
+++ b/cmd/exp/aws_config.go
@@ -3,6 +3,7 @@ package exp
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/chanzuckerberg/fogg/config"
@@ -128,14 +129,12 @@ var awsConfigCmd = &cobra.Command{
 		}
 
 		// Create directories in the aws config path if they doesn't exist already.
-		dirName := filepath.Dir(fileName)
-		if _, err := os.Stat(dirName); err != nil {
-			err := os.MkdirAll(dirName, os.ModePerm)
-			if err != nil {
+		dirName := filepath.Dir(awsConfigPath)
+		err := os.MkdirAll(dirName, os.ModePerm)
+		if err != nil {
 				return err
-			}
 		}
-
+		
 		awsConfigFile, err := os.OpenFile(awsConfigPath, os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {
 			return err

--- a/cmd/exp/aws_config.go
+++ b/cmd/exp/aws_config.go
@@ -130,7 +130,7 @@ var awsConfigCmd = &cobra.Command{
 
 		// Create directories in the aws config path if they doesn't exist already.
 		dirName := filepath.Dir(awsConfigPath)
-		err := os.MkdirAll(dirName, os.ModePerm)
+		err = os.MkdirAll(dirName, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/cmd/exp/aws_config.go
+++ b/cmd/exp/aws_config.go
@@ -132,7 +132,7 @@ var awsConfigCmd = &cobra.Command{
 		dirName := filepath.Dir(awsConfigPath)
 		err := os.MkdirAll(dirName, os.ModePerm)
 		if err != nil {
-				return err
+			return err
 		}
 		
 		awsConfigFile, err := os.OpenFile(awsConfigPath, os.O_WRONLY|os.O_CREATE, 0600)


### PR DESCRIPTION
…t already

### Summary
We are using `os.OpenFile` to create the awsconfig file. This will fail if any directories in the path doesn't exist as it is happening in my case. Added code to create any non existing directories in the path.

### Test Plan
Tested the code change locally.

### References
(Optional) Additional links to provide more context.
