### PR TITLE
[fix] triggering heroku auth checks

### DIFF
--- a/templates/account/Makefile.tmpl
+++ b/templates/account/Makefile.tmpl
@@ -9,6 +9,10 @@ export AWS_BACKEND_PROFILE := {{ .Backend.Profile }}
 {{if .Providers.AWS}}
 export AWS_PROVIDER_PROFILE := {{ .Providers.AWS.Profile }}
 {{ end }}
+{{if .Providers.Heroku}}
+export HEROKU_PROVIDER := 1
+{{end}}
+
 
 include {{ .PathToRepoRoot }}/scripts/component.mk
 

--- a/templates/global/Makefile.tmpl
+++ b/templates/global/Makefile.tmpl
@@ -4,6 +4,15 @@
 export TERRAFORM_VERSION := {{ .TerraformVersion }}
 export TFLINT_ENABLED := {{ if .TfLint.Enabled }}1{{ else }}0{{ end }}
 export TF_PLUGIN_CACHE_DIR := {{ .PathToRepoRoot }}/.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := {{ if .Atlantis.Enabled }}1{{ else }}0{{ end }}
+export AWS_BACKEND_PROFILE := {{ .Backend.Profile }}
+{{if .Providers.AWS}}
+export AWS_PROVIDER_PROFILE := {{ .Providers.AWS.Profile }}
+{{ end }}
+{{if .Providers.Heroku}}
+export HEROKU_PROVIDER := 1
+{{end}}
+
 
 include {{ .PathToRepoRoot }}/scripts/component.mk
 

--- a/testdata/bless_provider/terraform/accounts/foo/Makefile
+++ b/testdata/bless_provider/terraform/accounts/foo/Makefile
@@ -8,9 +8,12 @@ export ATLANTIS_ENABLED := 0
 export AWS_BACKEND_PROFILE := foofoo
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/bless_provider/terraform/global/Makefile
+++ b/testdata/bless_provider/terraform/global/Makefile
@@ -4,6 +4,11 @@
 export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := foofoo
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +16,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/github_provider/terraform/accounts/foo/Makefile
+++ b/testdata/github_provider/terraform/accounts/foo/Makefile
@@ -8,9 +8,12 @@ export ATLANTIS_ENABLED := 0
 export AWS_BACKEND_PROFILE := foo
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/github_provider/terraform/global/Makefile
+++ b/testdata/github_provider/terraform/global/Makefile
@@ -4,6 +4,11 @@
 export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := foo
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +16,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/okta_provider/terraform/accounts/foo/Makefile
+++ b/testdata/okta_provider/terraform/accounts/foo/Makefile
@@ -8,9 +8,12 @@ export ATLANTIS_ENABLED := 0
 export AWS_BACKEND_PROFILE := foofoo
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/okta_provider/terraform/global/Makefile
+++ b/testdata/okta_provider/terraform/global/Makefile
@@ -4,6 +4,11 @@
 export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := foofoo
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +16,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/snowflake_provider/terraform/accounts/foo/Makefile
+++ b/testdata/snowflake_provider/terraform/accounts/foo/Makefile
@@ -8,9 +8,12 @@ export ATLANTIS_ENABLED := 0
 export AWS_BACKEND_PROFILE := foo
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/snowflake_provider/terraform/global/Makefile
+++ b/testdata/snowflake_provider/terraform/global/Makefile
@@ -4,6 +4,11 @@
 export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := foo
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +16,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v1_full/terraform/accounts/bar/Makefile
+++ b/testdata/v1_full/terraform/accounts/bar/Makefile
@@ -10,9 +10,12 @@ export AWS_BACKEND_PROFILE := czi-bar
 export AWS_PROVIDER_PROFILE := czi-bar
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v1_full/terraform/accounts/foo/Makefile
+++ b/testdata/v1_full/terraform/accounts/foo/Makefile
@@ -10,9 +10,12 @@ export AWS_BACKEND_PROFILE := czi-foo
 export AWS_PROVIDER_PROFILE := czi-foo
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v1_full/terraform/global/Makefile
+++ b/testdata/v1_full/terraform/global/Makefile
@@ -4,6 +4,13 @@
 export TERRAFORM_VERSION := 0.11.0
 export TFLINT_ENABLED := 1
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := czi
+
+export AWS_PROVIDER_PROFILE := czi
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +18,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/terraform/accounts/bar/Makefile
+++ b/testdata/v2_full/terraform/accounts/bar/Makefile
@@ -10,9 +10,12 @@ export AWS_BACKEND_PROFILE := profile
 export AWS_PROVIDER_PROFILE := profile
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/terraform/accounts/foo/Makefile
+++ b/testdata/v2_full/terraform/accounts/foo/Makefile
@@ -10,9 +10,12 @@ export AWS_BACKEND_PROFILE := profile
 export AWS_PROVIDER_PROFILE := profile
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_full/terraform/global/Makefile
+++ b/testdata/v2_full/terraform/global/Makefile
@@ -4,6 +4,13 @@
 export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 1
+export AWS_BACKEND_PROFILE := profile
+
+export AWS_PROVIDER_PROFILE := profile
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +18,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_minimal_valid/terraform/global/Makefile
+++ b/testdata/v2_minimal_valid/terraform/global/Makefile
@@ -4,6 +4,11 @@
 export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := foo
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +16,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/Makefile
@@ -8,9 +8,12 @@ export ATLANTIS_ENABLED := 0
 export AWS_BACKEND_PROFILE := profile
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/Makefile
@@ -8,9 +8,12 @@ export ATLANTIS_ENABLED := 0
 export AWS_BACKEND_PROFILE := profile
 
 
+
+
 include ../../..//scripts/component.mk
 
 
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+

--- a/testdata/v2_no_aws_provider/terraform/global/Makefile
+++ b/testdata/v2_no_aws_provider/terraform/global/Makefile
@@ -4,6 +4,11 @@
 export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
+export ATLANTIS_ENABLED := 0
+export AWS_BACKEND_PROFILE := profile
+
+
+
 
 include ../..//scripts/component.mk
 
@@ -11,3 +16,4 @@ include ../..//scripts/component.mk
 help: ## display help for this makefile
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
+


### PR DESCRIPTION
When intially built in b93a1d6d3f5b6a2395015b7fe2de4126415f1481, I
missed setting `HEROKU_PROVIDER` in accounts and global, which meant
that the heroku auth checks did not get run.

### Test Plan
* travis-ci tests

### References
* 
