### PR TITLE
[feature] pin null provider version

### DIFF
--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -127,14 +127,4 @@ data "terraform_remote_state" "{{ $accountName }}" {
 {{ end }}
 {{ end }}
 
-provider random {
-  version = "~> 2.2"
-}
-
-provider template {
-  version = "~> 2.1"
-}
-
-provider archive {
-  version = "~> 1.3"
-}
+{{ template "common_providers" }}

--- a/templates/common/common_providers.tmpl
+++ b/templates/common/common_providers.tmpl
@@ -1,0 +1,13 @@
+{{ define "common_providers" -}}
+provider random {
+  version = "~> 2.2"
+}
+
+provider template {
+  version = "~> 2.1"
+}
+
+provider archive {
+  version = "~> 1.3"
+}
+{{- end }}

--- a/templates/common/common_providers.tmpl
+++ b/templates/common/common_providers.tmpl
@@ -10,4 +10,8 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}
 {{- end }}

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -170,14 +170,4 @@ variable "aws_accounts" {
   }
 }
 
-provider random {
-  version = "~> 2.2"
-}
-
-provider template {
-  version = "~> 2.1"
-}
-
-provider archive {
-  version = "~> 1.3"
-}
+{{ template "common_providers" }}

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -129,14 +129,4 @@ data "terraform_remote_state" "{{ $component }}" {
 }
 {{ end }}
 
-provider random {
-  version = "~> 2.2"
-}
-
-provider template {
-  version = "~> 2.1"
-}
-
-provider archive {
-  version = "~> 1.3"
-}
+{{ template "common_providers" }}

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -21,7 +21,7 @@ func TestOpenTemplate(t *testing.T) {
 		tLen    int
 		wantErr bool
 	}{
-		{"foo", args{temps.Account, "Makefile.tmpl"}, 8, false},
+		{"foo", args{temps.Account, "Makefile.tmpl"}, 9, false},
 	}
 
 	for _, tt := range tests {

--- a/testdata/bless_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider/terraform/accounts/foo/fogg.tf
@@ -104,3 +104,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -143,3 +143,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/bless_provider/terraform/global/fogg.tf
+++ b/testdata/bless_provider/terraform/global/fogg.tf
@@ -105,3 +105,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider/terraform/accounts/foo/fogg.tf
@@ -88,3 +88,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -127,3 +127,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/global/fogg.tf
+++ b/testdata/github_provider/terraform/global/fogg.tf
@@ -89,3 +89,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider/terraform/accounts/foo/fogg.tf
@@ -88,3 +88,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -127,3 +127,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/global/fogg.tf
+++ b/testdata/okta_provider/terraform/global/fogg.tf
@@ -89,3 +89,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -89,3 +89,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -128,3 +128,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider/terraform/global/fogg.tf
@@ -90,3 +90,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -133,3 +133,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -133,3 +133,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -183,3 +183,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -183,3 +183,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/global/fogg.tf
+++ b/testdata/v1_full/terraform/global/fogg.tf
@@ -114,3 +114,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -125,3 +125,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -125,3 +125,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -187,3 +187,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -187,3 +187,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -187,3 +187,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/global/fogg.tf
+++ b/testdata/v2_full/terraform/global/fogg.tf
@@ -106,3 +106,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_minimal_valid/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid/terraform/global/fogg.tf
@@ -80,3 +80,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -100,3 +100,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -100,3 +100,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -161,3 +161,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -161,3 +161,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -161,3 +161,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/global/fogg.tf
@@ -85,3 +85,7 @@ provider template {
 provider archive {
   version = "~> 1.3"
 }
+
+provider null {
+  version = "~> 2.1"
+}


### PR DESCRIPTION
We now pin the version of the terraform null provider. The version is hard-coded, but we can make it configurable when we need to.

This is part of efforts to have reproducible runs & reduce noise in terraform's output.

### Test Plan
* travis-ci

### References
*
