### PR TITLE
[feature] pin versions of tls and local providers

### DIFF
--- a/templates/common/common_providers.tmpl
+++ b/templates/common/common_providers.tmpl
@@ -14,4 +14,12 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}
 {{- end }}

--- a/testdata/bless_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider/terraform/accounts/foo/fogg.tf
@@ -108,3 +108,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -147,3 +147,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/bless_provider/terraform/global/fogg.tf
+++ b/testdata/bless_provider/terraform/global/fogg.tf
@@ -109,3 +109,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider/terraform/accounts/foo/fogg.tf
@@ -92,3 +92,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -131,3 +131,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/github_provider/terraform/global/fogg.tf
+++ b/testdata/github_provider/terraform/global/fogg.tf
@@ -93,3 +93,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider/terraform/accounts/foo/fogg.tf
@@ -92,3 +92,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -131,3 +131,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/okta_provider/terraform/global/fogg.tf
+++ b/testdata/okta_provider/terraform/global/fogg.tf
@@ -93,3 +93,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -93,3 +93,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -132,3 +132,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/snowflake_provider/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider/terraform/global/fogg.tf
@@ -94,3 +94,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -137,3 +137,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -137,3 +137,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -187,3 +187,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -187,3 +187,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v1_full/terraform/global/fogg.tf
+++ b/testdata/v1_full/terraform/global/fogg.tf
@@ -118,3 +118,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -129,3 +129,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -129,3 +129,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -191,3 +191,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -191,3 +191,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -191,3 +191,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_full/terraform/global/fogg.tf
+++ b/testdata/v2_full/terraform/global/fogg.tf
@@ -110,3 +110,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_minimal_valid/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid/terraform/global/fogg.tf
@@ -84,3 +84,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -104,3 +104,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -104,3 +104,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -165,3 +165,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -165,3 +165,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -165,3 +165,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}

--- a/testdata/v2_no_aws_provider/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/global/fogg.tf
@@ -89,3 +89,11 @@ provider archive {
 provider null {
   version = "~> 2.1"
 }
+
+provider local {
+  version = "~> 1.4"
+}
+
+provider tls {
+  version = "~> 2.1"
+}


### PR DESCRIPTION
This pins the versions of these providers. They are currently hard-coded, but we can configure them when we need to.

### Test Plan
* unit tests

### References
* 
