### PR TITLE
[fix] remove deprecated sudo command from travis configuartion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: bionic
 language: go
-sudo: false
 go:
   - "1.13.1"
 env:

--- a/templates/travis-ci/.travis.yml.tmpl
+++ b/templates/travis-ci/.travis.yml.tmpl
@@ -3,7 +3,6 @@
 # Make improvements in fogg, so that everyone can benefit.
 dist: bionic
 language: python
-sudo: required
 python: 3.6
 env:
   global:

--- a/testdata/v1_full/.travis.yml
+++ b/testdata/v1_full/.travis.yml
@@ -3,7 +3,6 @@
 # Make improvements in fogg, so that everyone can benefit.
 dist: bionic
 language: python
-sudo: required
 python: 3.6
 env:
   global:


### PR DESCRIPTION
### Summary
sudo keyword is fully deprecated in travis CI.  made changes to remove it from the travis configuration file.

### Test Plan
ran make test locally

