### PR TITLE
[feature] add datadog provider

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -100,6 +100,7 @@ type Providers struct {
 	Heroku    *HerokuProvider    `json:"heroku,omitempty" yaml:"heroku,omitempty"`
 	Okta      *OktaProvider      `json:"okta,omitempty" yaml:"okta,omitempty"`
 	Snowflake *SnowflakeProvider `json:"snowflake,omitempty" yaml:"snowflake,omitempty"`
+	Datadog   *DatadogProvider   `json:"datadog,omitempty" yaml:"datadog,omitempty"`
 }
 
 // OktaProvider is an okta provider
@@ -141,6 +142,8 @@ type SnowflakeProvider struct {
 }
 
 type HerokuProvider struct{}
+
+type DatadogProvider struct{}
 
 type Backend struct {
 	AccountID   *string `json:"account_id,omitempty" yaml:"account_id,omitempty"`
@@ -249,6 +252,13 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 		return nil
 	}
 
+	randDatadogProvider := func(r *rand.Rand, s int) *DatadogProvider {
+		if r.Float32() < 0.5 {
+			return &DatadogProvider{}
+		}
+		return nil
+	}
+
 	randCommon := func(r *rand.Rand, s int) Common {
 		c := Common{
 			Backend: &Backend{
@@ -264,6 +274,7 @@ func (c *Config) Generate(r *rand.Rand, size int) reflect.Value {
 				Okta:      randOktaProvider(r, s),
 				Bless:     randBlessProvider(r, s),
 				Heroku:    randHerokuProvider(r, s),
+				Datadog:   randDatadogProvider(r, s),
 			},
 			TerraformVersion: randStringPtr(r, s),
 		}

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -193,6 +193,18 @@ func ResolveHerokuProvider(commons ...Common) *HerokuProvider {
 	return p
 }
 
+func ResolveDatadogProvider(commons ...Common) *DatadogProvider {
+	var p *DatadogProvider
+	for _, c := range commons {
+		if c.Providers == nil || c.Providers.Datadog == nil {
+			continue
+		}
+		p = c.Providers.Datadog
+	}
+
+	return p
+}
+
 func ResolveTfLint(commons ...Common) v1.TfLint {
 	enabled := false
 	for _, c := range commons {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -111,6 +111,7 @@ type Providers struct {
 	Snowflake *SnowflakeProvider `yaml:"snowflake"`
 	Bless     *BlessProvider     `yaml:"bless"`
 	Okta      *OktaProvider      `yaml:"okta"`
+	Datadog   *DatadogProvider   `yaml:"datadog"`
 }
 
 //AWSProvider represents AWS provider configuration
@@ -152,6 +153,8 @@ type BlessProvider struct {
 }
 
 type HerokuProvider struct{}
+
+type DatadogProvider struct{}
 
 // AWSBackend represents aws backend configuration
 type AWSBackend struct {
@@ -397,6 +400,12 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		herokuPlan = &HerokuProvider{}
 	}
 
+	var datadogPlan *DatadogProvider
+	datadogConfig := v2.ResolveDatadogProvider(commons...)
+	if datadogConfig != nil {
+		datadogPlan = &DatadogProvider{}
+	}
+
 	tflintConfig := v2.ResolveTfLint(commons...)
 
 	tfLintPlan := TfLint{
@@ -446,6 +455,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 			Snowflake: snowflakePlan,
 			Bless:     blessPlan,
 			Okta:      oktaPlan,
+			Datadog:   datadogPlan,
 		},
 		TfLint:    tfLintPlan,
 		ExtraVars: v2.ResolveStringMap(v2.ExtraVarsGetter, commons...),

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -2,7 +2,6 @@ package plan
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/chanzuckerberg/fogg/config"
@@ -203,12 +202,9 @@ func TestPlanBasicV2Yaml(t *testing.T) {
 	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers)
 	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers.Heroku)
 
-	fmt.Println("VALUE1:", plan.Envs["prod"].Components["hero"].Providers.Heroku)
-	fmt.Println("VALUE2:", plan.Envs["prod"].Components["datadog"].Providers.Datadog)
 	assert.NotNil(t, plan.Envs["prod"])
 	assert.NotNil(t, plan.Envs["prod"].Components["datadog"])
 	assert.NotNil(t, plan.Envs["prod"].Components["datadog"].Providers)
-	fmt.Println("VALUE3:", plan)
 	assert.NotNil(t, plan.Envs["prod"].Components["datadog"].Providers.Datadog)
 }
 

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/chanzuckerberg/fogg/config"
@@ -201,6 +202,14 @@ func TestPlanBasicV2Yaml(t *testing.T) {
 	assert.NotNil(t, plan.Envs["prod"].Components["hero"])
 	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers)
 	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers.Heroku)
+
+	fmt.Println("VALUE1:", plan.Envs["prod"].Components["hero"].Providers.Heroku)
+	fmt.Println("VALUE2:", plan.Envs["prod"].Components["datadog"].Providers.Datadog)
+	assert.NotNil(t, plan.Envs["prod"])
+	assert.NotNil(t, plan.Envs["prod"].Components["datadog"])
+	assert.NotNil(t, plan.Envs["prod"].Components["datadog"].Providers)
+	fmt.Println("VALUE3:", plan)
+	assert.NotNil(t, plan.Envs["prod"].Components["datadog"].Providers.Datadog)
 }
 
 func TestExtraVarsCompositionV2(t *testing.T) {

--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -43,6 +43,10 @@
   {{ template "heroku_provider" .Providers.Heroku }}
 {{ end }}
 
+{{ if .Providers.Datadog }}
+  {{ template "datadog_provider" .Providers.Datadog }}
+{{ end }}
+
 terraform {
   required_version = "={{ .TerraformVersion }}"
 

--- a/templates/common/datadog_provider.tmpl
+++ b/templates/common/datadog_provider.tmpl
@@ -1,0 +1,4 @@
+{{define "datadog_provider"}}
+provider "datadog" {
+}
+{{ end }}

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -43,6 +43,10 @@
   {{ template "heroku_provider" .Providers.Heroku }}
 {{ end }}
 
+{{ if .Providers.Datadog }}
+  {{ template "datadog_provider" .Providers.Datadog }}
+{{ end }}
+
 terraform {
   required_version = "~>{{ .TerraformVersion }}"
 

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -42,6 +42,10 @@
   {{ template "heroku_provider" .Providers.Heroku }}
 {{ end }}
 
+{{ if .Providers.Datadog }}
+  {{ template "datadog_provider" .Providers.Datadog }}
+{{ end }}
+
 
 terraform {
   required_version = "~>{{ .TerraformVersion }}"

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -21,7 +21,7 @@ func TestOpenTemplate(t *testing.T) {
 		tLen    int
 		wantErr bool
 	}{
-		{"foo", args{temps.Account, "Makefile.tmpl"}, 9, false},
+		{"foo", args{temps.Account, "Makefile.tmpl"}, 10, false},
 	}
 
 	for _, tt := range tests {

--- a/testdata/bless_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider/terraform/accounts/foo/fogg.tf
@@ -38,6 +38,8 @@ provider "bless" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider/terraform/envs/bar/bam/fogg.tf
@@ -38,6 +38,8 @@ provider "bless" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/bless_provider/terraform/global/fogg.tf
+++ b/testdata/bless_provider/terraform/global/fogg.tf
@@ -39,6 +39,8 @@ provider "bless" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/github_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider/terraform/accounts/foo/fogg.tf
@@ -22,6 +22,8 @@ provider "github" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider/terraform/envs/bar/bam/fogg.tf
@@ -22,6 +22,8 @@ provider "github" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/github_provider/terraform/global/fogg.tf
+++ b/testdata/github_provider/terraform/global/fogg.tf
@@ -23,6 +23,8 @@ provider "github" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/okta_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider/terraform/accounts/foo/fogg.tf
@@ -22,6 +22,8 @@ provider "okta" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider/terraform/envs/bar/bam/fogg.tf
@@ -22,6 +22,8 @@ provider "okta" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/okta_provider/terraform/global/fogg.tf
+++ b/testdata/okta_provider/terraform/global/fogg.tf
@@ -23,6 +23,8 @@ provider "okta" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider/terraform/accounts/foo/fogg.tf
@@ -23,6 +23,8 @@ provider "snowflake" {
 
 
 
+
+
 terraform {
   required_version = "=1.1.1"
 

--- a/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider/terraform/envs/bar/bam/fogg.tf
@@ -23,6 +23,8 @@ provider "snowflake" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/snowflake_provider/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider/terraform/global/fogg.tf
@@ -24,6 +24,8 @@ provider "snowflake" {
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/v1_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/bar/fogg.tf
@@ -32,6 +32,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.13.0"
 

--- a/testdata/v1_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v1_full/terraform/accounts/foo/fogg.tf
@@ -32,6 +32,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.12.0"
 

--- a/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/cloud-env/fogg.tf
@@ -33,6 +33,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.15.0"
 

--- a/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
+++ b/testdata/v1_full/terraform/envs/stage/helm/fogg.tf
@@ -33,6 +33,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.14.0"
 

--- a/testdata/v1_full/terraform/global/fogg.tf
+++ b/testdata/v1_full/terraform/global/fogg.tf
@@ -33,6 +33,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.11.0"
 

--- a/testdata/v2_full/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/bar/fogg.tf
@@ -24,6 +24,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_full/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full/terraform/accounts/foo/fogg.tf
@@ -24,6 +24,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp1/fogg.tf
@@ -25,6 +25,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/comp2/fogg.tf
@@ -25,6 +25,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full/terraform/envs/staging/vpc/fogg.tf
@@ -25,6 +25,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full/terraform/global/fogg.tf
+++ b/testdata/v2_full/terraform/global/fogg.tf
@@ -25,6 +25,8 @@ provider "aws" {
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full_yaml/fogg.yml
+++ b/testdata/v2_full_yaml/fogg.yml
@@ -29,6 +29,9 @@ envs:
       hero:
         providers:
           heroku: {}
+      datadog:
+        providers:
+          datadog: {}
   staging:
     components:
       comp_helm_template:

--- a/testdata/v2_minimal_valid/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid/terraform/global/fogg.tf
@@ -14,6 +14,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>1.1.1"
 

--- a/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/bar/fogg.tf
@@ -13,6 +13,8 @@
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/accounts/foo/fogg.tf
@@ -13,6 +13,8 @@
 
 
 
+
+
 terraform {
   required_version = "=0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp1/fogg.tf
@@ -13,6 +13,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/comp2/fogg.tf
@@ -13,6 +13,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/envs/staging/vpc/fogg.tf
@@ -13,6 +13,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_no_aws_provider/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider/terraform/global/fogg.tf
@@ -14,6 +14,8 @@
 
 
 
+
+
 terraform {
   required_version = "~>0.100.0"
 


### PR DESCRIPTION
### Summary
This PR enables adding datadog provider.

We need to set DATADOG_APP_KEY and DATADOG_API_KEY environment variables.
It cannot pin versions currently.

### Test Plan
1. unittests.
2. tested in local repo.