### PR TITLE
[feature] add ability to run a cpu profile

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ var rootCmd = &cobra.Command{
 	Use:          "fogg",
 	Short:        "",
 	SilenceUsage: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Inside rootCmd PersistentPreRun with args: %v\n", args)
 		if cpuprofile != "" {
 			log.Println("starting cpu profile")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime/pprof"
 
 	"github.com/chanzuckerberg/fogg/cmd/exp"
 	"github.com/chanzuckerberg/fogg/errs"
 	"github.com/fatih/color"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,17 +29,21 @@ var rootCmd = &cobra.Command{
 	Use:          "fogg",
 	Short:        "",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Inside rootCmd PersistentPreRun with args: %v\n", args)
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cpuprofile != "" {
-			log.Println("starting cpu profile")
+			logrus.Info("starting cpu profile")
 			f, err := os.Create(cpuprofile)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
-			pprof.StartCPUProfile(f)
-			defer pprof.StopCPUProfile()
+			return pprof.StartCPUProfile(f)
 		}
+		return nil
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		logrus.Info("stopping cpu profile")
+		pprof.StopCPUProfile()
+		return nil
 	},
 }
 


### PR DESCRIPTION
This enables running cpu profiles and writing them to disk. They can be analyzed with [standard go tools](https://blog.golang.org/pprof)

### Test Plan
* CI

### References
* https://blog.golang.org/pprof