### PR TITLE
[testing] replace assert with require

### DIFF
--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -48,44 +47,45 @@ func getNonExistentDirectoryName() string {
 }
 
 func TestRemoveExtension(t *testing.T) {
+	r := require.New(t)
 	x := removeExtension("foo")
-	assert.Equal(t, "foo", x)
+	r.Equal("foo", x)
 
 	x = removeExtension("foo.txt")
-	assert.Equal(t, "foo", x)
+	r.Equal("foo", x)
 
 	x = removeExtension("foo.txt.asdf")
-	assert.Equal(t, "foo.txt", x)
+	r.Equal("foo.txt", x)
 
 	x = removeExtension("foo/bar.txt")
-	assert.Equal(t, "foo/bar", x)
+	r.Equal("foo/bar", x)
 }
 
 func TestApplyTemplateBasic(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	sourceFile := strings.NewReader("foo")
 	dest, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.Remove(d)
 
 	path := "bar"
 	overrides := struct{ Foo string }{"foo"}
 
 	e := applyTemplate(sourceFile, &templates.Templates.Common, dest, path, overrides)
-	a.Nil(e)
+	r.Nil(e)
 	f, e := dest.Open("bar")
-	a.Nil(e)
-	r, e := ioutil.ReadAll(f)
-	a.Nil(e)
-	a.Equal("foo", string(r))
+	r.Nil(e)
+	i, e := ioutil.ReadAll(f)
+	r.Nil(e)
+	r.Equal("foo", string(i))
 }
 
 func TestApplyTemplateBasicNewDirectory(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	sourceFile := strings.NewReader("foo")
 
 	dest, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	nonexistentDir := getNonExistentDirectoryName()
@@ -94,128 +94,127 @@ func TestApplyTemplateBasicNewDirectory(t *testing.T) {
 	overrides := struct{ Foo string }{"foo"}
 
 	e := applyTemplate(sourceFile, &templates.Templates.Common, dest, path, overrides)
-	a.Nil(e)
+	r.Nil(e)
 	f, e := dest.Open(path)
-	a.Nil(e)
-	r, e := ioutil.ReadAll(f)
-	a.Nil(e)
-	a.Equal("foo", string(r))
+	r.Nil(e)
+	i, e := ioutil.ReadAll(f)
+	r.Nil(e)
+	r.Equal("foo", string(i))
 }
 
 func TestApplyTemplate(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	sourceFile := strings.NewReader("Hello {{.Name}}")
 	dest, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	path := "hello"
 	overrides := struct{ Name string }{"World"}
 
 	e := applyTemplate(sourceFile, &templates.Templates.Common, dest, path, overrides)
-	a.Nil(e)
+	r.Nil(e)
 	f, e := dest.Open("hello")
-	a.Nil(e)
-	r, e := ioutil.ReadAll(f)
-	a.Nil(e)
-	a.Equal("Hello World", string(r))
+	r.Nil(e)
+	i, e := ioutil.ReadAll(f)
+	r.Nil(e)
+	r.Equal("Hello World", string(i))
 }
 
 func TestTouchFile(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	e := touchFile(fs, "foo")
-	a.Nil(e)
-	r, e := readFile(fs, "foo")
-	a.Nil(e)
-	a.Equal("", r)
+	r.Nil(e)
+	i, e := readFile(fs, "foo")
+	r.Nil(e)
+	r.Equal("", i)
 
 	fs, d2, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d2)
 
 	err = writeFile(fs, "asdf", "jkl")
-	a.NoError(err)
+	r.NoError(err)
 
-	r, e = readFile(fs, "asdf")
-	a.Nil(e)
-	a.Equal("jkl", r)
+	i, e = readFile(fs, "asdf")
+	r.Nil(e)
+	r.Equal("jkl", i)
 
 	e = touchFile(fs, "asdf")
-	a.Nil(e)
-	r, e = readFile(fs, "asdf")
-	a.Nil(e)
-	a.Equal("jkl", r)
+	r.Nil(e)
+	i, e = readFile(fs, "asdf")
+	r.Nil(e)
+	r.Equal("jkl", i)
 }
 
 func TestTouchFileNonExistentDirectory(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	dest, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	nonexistentDir := getNonExistentDirectoryName()
 	defer dest.RemoveAll(nonexistentDir) //nolint
 	e := touchFile(dest, filepath.Join(nonexistentDir, "foo"))
-	a.Nil(e)
-	r, e := readFile(dest, filepath.Join(nonexistentDir, "foo"))
-	a.Nil(e)
-	a.Equal("", r)
-	a.Nil(e)
+	r.Nil(e)
+	i, e := readFile(dest, filepath.Join(nonexistentDir, "foo"))
+	r.Nil(e)
+	r.Equal("", i)
+	r.Nil(e)
 }
 
 func TestCreateFile(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	// create new file
 
 	e := createFile(fs, "foo", strings.NewReader("bar"))
-	a.Nil(e)
+	r.Nil(e)
 
-	r, e := readFile(fs, "foo")
-	a.Nil(e)
-	a.Equal("bar", r)
+	i, e := readFile(fs, "foo")
+	r.Nil(e)
+	r.Equal("bar", i)
 
 	// not overwrite existing file
 
 	fs, d2, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d2)
 
 	e = createFile(fs, "foo", strings.NewReader("bar"))
-	a.Nil(e)
+	r.Nil(e)
 
-	r, e = readFile(fs, "foo")
-	a.Nil(e)
-	a.Equal("bar", r)
+	i, e = readFile(fs, "foo")
+	r.Nil(e)
+	r.Equal("bar", i)
 
 	e = createFile(fs, "foo", strings.NewReader("BAM"))
-	a.Nil(e)
+	r.Nil(e)
 
-	r, e = readFile(fs, "foo")
-	a.Nil(e)
-	a.Equal("bar", r)
+	i, e = readFile(fs, "foo")
+	r.Nil(e)
+	r.Equal("bar", i)
 }
 
 func TestCreateFileNonExistentDirectory(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	// create new file in nonexistent directory
 	dest, _, e := util.TestFs()
-	a.NoError(e)
+	r.NoError(e)
 
 	e = createFile(dest, "newdir/foo", strings.NewReader("bar"))
-	a.NoError(e)
+	r.NoError(e)
 
-	r, e := readFile(dest, "newdir/foo")
-	a.NoError(e)
-	a.Equal("bar", r)
-
+	i, e := readFile(dest, "newdir/foo")
+	r.NoError(e)
+	r.Equal("bar", i)
 }
 
 func TestApplySmokeTest(t *testing.T) {
@@ -250,35 +249,35 @@ version: 2
 }
 
 func TestApplyModuleInvocation(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	testFs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 	pwdFs, err := util.PwdFs()
-	a.NoError(err)
+	r.NoError(err)
 
 	fs := afero.NewCopyOnWriteFs(pwdFs, testFs)
 
 	e := applyModuleInvocation(fs, "mymodule", "test-module", templates.Templates.ModuleInvocation, &templates.Templates.Common)
-	a.NoError(e)
+	r.NoError(e)
 
 	s, e := fs.Stat("mymodule")
-	a.Nil(e)
-	a.True(s.IsDir())
+	r.Nil(e)
+	r.True(s.IsDir())
 
 	_, e = fs.Stat("mymodule/main.tf")
-	a.Nil(e)
-	r, e := afero.ReadFile(fs, "mymodule/main.tf")
-	a.Nil(e)
+	r.Nil(e)
+	i, e := afero.ReadFile(fs, "mymodule/main.tf")
+	r.Nil(e)
 	expected := "# Auto-generated by fogg. Do not edit\n# Make improvements in fogg, so that everyone can benefit.\n\nmodule \"test-module\" {\n  source = \"../test-module\"\n  bar    = local.bar\n  foo    = local.foo\n\n}\n"
-	a.Equal(expected, string(r))
+	r.Equal(expected, string(i))
 
 	_, e = fs.Stat("mymodule/outputs.tf")
-	a.Nil(e)
-	r, e = afero.ReadFile(fs, "mymodule/outputs.tf")
-	a.Nil(e)
+	r.Nil(e)
+	i, e = afero.ReadFile(fs, "mymodule/outputs.tf")
+	r.Nil(e)
 	expected = "# Auto-generated by fogg. Do not edit\n# Make improvements in fogg, so that everyone can benefit.\n\noutput \"bar\" {\n  value = module.test-module.bar\n}\n\noutput \"foo\" {\n  value = module.test-module.foo\n}\n\n\n"
-	a.Equal(expected, string(r))
+	r.Equal(expected, string(i))
 }
 func TestGetTargetPath(t *testing.T) {
 	data := []struct {
@@ -297,31 +296,32 @@ func TestGetTargetPath(t *testing.T) {
 	}
 	for _, test := range data {
 		t.Run(test.source, func(t *testing.T) {
+			r := require.New(t)
 			out := getTargetPath(test.base, test.source)
-			assert.Equal(t, test.output, out)
+			r.Equal(test.output, out)
 		})
 	}
 }
 
 func TestFmtHcl(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	before := `foo { bar     = "bam"}`
 	after := `foo { bar = "bam" }`
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	in := strings.NewReader(before)
 	e := afero.WriteReader(fs, "foo.tf", in)
-	a.Nil(e)
+	r.Nil(e)
 	e = fmtHcl(fs, "foo.tf")
-	a.Nil(e)
+	r.Nil(e)
 	out, e := afero.ReadFile(fs, "foo.tf")
-	a.Nil(e)
-	a.NotNil(out)
+	r.Nil(e)
+	r.NotNil(out)
 	s := string(out)
-	a.Equal(after, s)
+	r.Equal(after, s)
 }
 
 func TestCalculateLocalPath(t *testing.T) {
@@ -345,9 +345,10 @@ func TestCalculateLocalPath(t *testing.T) {
 
 	for _, test := range data {
 		t.Run("", func(t *testing.T) {
+			r := require.New(t)
 			p, e := calculateModuleAddressForSource(test.path, test.moduleAddress)
-			assert.Nil(t, e)
-			assert.Equal(t, test.expected, p)
+			r.Nil(e)
+			r.Equal(test.expected, p)
 		})
 	}
 }
@@ -370,29 +371,29 @@ var versionTests = []struct {
 func TestCheckToolVersions(t *testing.T) {
 	for _, tc := range versionTests {
 		t.Run("", func(t *testing.T) {
-			a := assert.New(t)
+			r := require.New(t)
 			fs, d, err := util.TestFs()
-			a.NoError(err)
+			r.NoError(err)
 			defer os.RemoveAll(d)
 
 			err = writeFile(fs, ".fogg-version", tc.current)
-			a.NoError(err)
+			r.NoError(err)
 
 			v, _, e := checkToolVersions(fs, tc.tool)
-			a.NoError(e)
-			a.Equal(tc.result, v)
+			r.NoError(e)
+			r.Equal(tc.result, v)
 		})
 	}
 }
 
 func TestVersionIsChanged(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	for _, test := range versionTests {
 		t.Run("", func(t *testing.T) {
 			b, e := versionIsChanged(test.current, test.tool)
-			a.NoError(e)
-			a.Equal(test.result, b)
+			r.NoError(e)
+			r.Equal(test.result, b)
 		})
 	}
 }

--- a/apply/golden_file_test.go
+++ b/apply/golden_file_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +37,6 @@ func TestIntegration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.fileName, func(t *testing.T) {
-			a := assert.New(t)
 			r := require.New(t)
 
 			testdataFs := afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(util.ProjectRoot(), "testdata", tc.fileName))
@@ -52,7 +50,7 @@ func TestIntegration(t *testing.T) {
 					}
 					return nil
 				})
-				a.NoError(e)
+				r.NoError(e)
 
 				conf, e := config.FindAndReadConfig(testdataFs, tc.configFile)
 				r.NoError(e)
@@ -68,7 +66,7 @@ func TestIntegration(t *testing.T) {
 			} else {
 				fileName := "fogg.yml"
 				fs, _, e := util.TestFs()
-				a.NoError(e)
+				r.NoError(e)
 
 				// copy tc.configFile into the tmp test dir (so that it doesn't show up as a diff)
 				configContents, e := afero.ReadFile(testdataFs, fileName)
@@ -76,24 +74,24 @@ func TestIntegration(t *testing.T) {
 					fileName = tc.configFile
 					configContents, e = afero.ReadFile(testdataFs, fileName)
 				}
-				a.NoError(e)
+				r.NoError(e)
 
 				configMode, e := testdataFs.Stat(fileName)
-				a.NoError(e)
-				a.NoError(afero.WriteFile(fs, fileName, configContents, configMode.Mode()))
+				r.NoError(e)
+				r.NoError(afero.WriteFile(fs, fileName, configContents, configMode.Mode()))
 
 				conf, e := config.FindAndReadConfig(fs, fileName)
-				a.NoError(e)
+				r.NoError(e)
 				fmt.Printf("conf %#v\n", conf)
 
 				w, e := conf.Validate()
-				a.NoError(e)
-				a.Len(w, 0)
+				r.NoError(e)
+				r.Len(w, 0)
 
 				e = apply.Apply(fs, conf, templates.Templates, true)
-				a.NoError(e)
+				r.NoError(e)
 
-				a.NoError(afero.Walk(testdataFs, ".", func(path string, info os.FileInfo, err error) error {
+				r.NoError(afero.Walk(testdataFs, ".", func(path string, info os.FileInfo, err error) error {
 					logrus.Debug("================================================")
 					logrus.Debug(path)
 					if !info.Mode().IsRegular() {
@@ -110,7 +108,7 @@ func TestIntegration(t *testing.T) {
 						logrus.Debugf("i1 size: %d ii2 size %d", i1.Size(), i2.Size())
 						r.Equalf(i1.Size(), i2.Size(), "file size: %s", path)
 						// This (below) doesn't currently work for files created on a mac then tested on linux. :shrug:
-						// a.Equalf(i1.Mode(), i2.Mode(), "file mode: %s, %o vs %o", path, i1.Mode(), i2.Mode())
+						// r.Equalf(i1.Mode(), i2.Mode(), "file mode: %s, %o vs %o", path, i1.Mode(), i2.Mode())
 
 						f1, e3 := afero.ReadFile(testdataFs, path)
 						r.NoError(e3)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,22 +7,22 @@ import (
 
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitConfig(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	c := InitConfig("proj", "reg", "buck", "table", "prof", "me@foo.example", "0.99.0")
-	a.Equal("prof", *c.Defaults.Common.Backend.Profile)
-	a.Equal("prof", *c.Defaults.Providers.AWS.Profile)
-	a.Equal("reg", *c.Defaults.Providers.AWS.Region)
-	a.Equal("reg", *c.Defaults.Providers.AWS.Region)
-	a.Equal("0.99.0", *c.Defaults.Providers.AWS.Version)
-	a.Equal("buck", *c.Defaults.Common.Backend.Bucket)
-	a.Equal("table", *c.Defaults.Common.Backend.DynamoTable)
-	a.Equal("me@foo.example", *c.Defaults.Owner)
-	a.Equal("proj", *c.Defaults.Project)
-	a.Equal(defaultTerraformVersion.String(), *c.Defaults.TerraformVersion)
+	r.Equal("prof", *c.Defaults.Common.Backend.Profile)
+	r.Equal("prof", *c.Defaults.Providers.AWS.Profile)
+	r.Equal("reg", *c.Defaults.Providers.AWS.Region)
+	r.Equal("reg", *c.Defaults.Providers.AWS.Region)
+	r.Equal("0.99.0", *c.Defaults.Providers.AWS.Version)
+	r.Equal("buck", *c.Defaults.Common.Backend.Bucket)
+	r.Equal("table", *c.Defaults.Common.Backend.DynamoTable)
+	r.Equal("me@foo.example", *c.Defaults.Owner)
+	r.Equal("proj", *c.Defaults.Project)
+	r.Equal(defaultTerraformVersion.String(), *c.Defaults.TerraformVersion)
 }
 
 func Test_detectVersion(t *testing.T) {
@@ -40,9 +40,10 @@ func Test_detectVersion(t *testing.T) {
 		{"explicit 2", args{[]byte(`{"version": 2}`)}, 2, false},
 		{"err", args{[]byte(`{`)}, 0, true},
 	}
-	a := assert.New(t)
+	r := require.New(t)
 	fs, _, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got int

--- a/config/v2/config_test.go
+++ b/config/v2/config_test.go
@@ -5,44 +5,43 @@ import (
 
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestReadConfig(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	b, e := util.TestFile("empty_yaml")
-	a.NoError(e)
+	r.NoError(e)
 
 	fs, _, e := util.TestFs()
-	a.NoError(e)
+	r.NoError(e)
 	e = afero.WriteFile(fs, "fogg.yml", b, 0644)
-	a.NoError(e)
+	r.NoError(e)
 	c, e := ReadConfig(fs, b, "fogg.yml")
-	a.NoError(e)
+	r.NoError(e)
 
 	w, e := c.Validate()
-	a.Error(e)
-	a.Len(w, 0)
+	r.Error(e)
+	r.Len(w, 0)
 }
 
 func TestReadConfigYaml(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	b2, e := util.TestFile("v2_minimal_valid_yaml")
-	a.NoError(e)
+	r.NoError(e)
 
 	fs, _, e := util.TestFs()
-	a.NoError(e)
+	r.NoError(e)
 	e = afero.WriteFile(fs, "fogg.yml", b2, 0644)
-	a.NoError(e)
+	r.NoError(e)
 	c, e := ReadConfig(fs, b2, "fogg.yml")
-	a.NoError(e)
+	r.NoError(e)
 
 	w, e := c.Validate()
-	a.NoError(e)
-	a.Len(w, 0)
+	r.NoError(e)
+	r.Len(w, 0)
 }
 
 func TestReadSnowflakeProviderYaml(t *testing.T) {

--- a/config/v2/resolvers_test.go
+++ b/config/v2/resolvers_test.go
@@ -4,35 +4,35 @@ import (
 	"testing"
 
 	v2 "github.com/chanzuckerberg/fogg/config/v2"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestResolveTfLint(test *testing.T) {
-	a := assert.New(test)
-	t := true
-	f := false
+func TestResolveTfLint(t *testing.T) {
+	r := require.New(t)
+	tru := true
+	fal := false
 
 	data := []struct {
 		def    *bool
 		over   *bool
 		output *bool
 	}{
-		{nil, nil, &f},
-		{nil, &t, &t},
-		{nil, &f, &f},
-		{&t, nil, &t},
-		{&t, &t, &t},
-		{&t, &f, &f},
-		{&f, nil, &f},
-		{&f, &t, &t},
-		{&f, &f, &f},
+		{nil, nil, &fal},
+		{nil, &tru, &tru},
+		{nil, &fal, &fal},
+		{&tru, nil, &tru},
+		{&tru, &tru, &tru},
+		{&tru, &fal, &fal},
+		{&fal, nil, &fal},
+		{&fal, &tru, &tru},
+		{&fal, &fal, &fal},
 	}
-	for _, r := range data {
-		test.Run("", func(t *testing.T) {
-			def := v2.Common{Tools: &v2.Tools{TfLint: &v2.TfLint{Enabled: r.def}}}
-			over := v2.Common{Tools: &v2.Tools{TfLint: &v2.TfLint{Enabled: r.over}}}
+	for _, tt := range data {
+		t.Run("", func(t *testing.T) {
+			def := v2.Common{Tools: &v2.Tools{TfLint: &v2.TfLint{Enabled: tt.def}}}
+			over := v2.Common{Tools: &v2.Tools{TfLint: &v2.TfLint{Enabled: tt.over}}}
 			result := v2.ResolveTfLint(def, over)
-			a.Equal(r.output, result.Enabled)
+			r.Equal(tt.output, result.Enabled)
 		})
 	}
 }

--- a/config/v2/validation_test.go
+++ b/config/v2/validation_test.go
@@ -5,24 +5,23 @@ import (
 
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_nonEmptyString(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	empty := ""
 	nonEmpty := "foo"
-	a.True(nonEmptyString(&nonEmpty))
-	a.False(nonEmptyString(&empty))
-	a.False(nonEmptyString(nil))
+	r.True(nonEmptyString(&nonEmpty))
+	r.False(nonEmptyString(&empty))
+	r.False(nonEmptyString(nil))
 }
 
 func TestValidateOwnersAccount(t *testing.T) {
 	// this will serve as a test for all the fuctions that use validateInheritedStringField, since they are equivalent
 
-	a := assert.New(t)
+	r := require.New(t)
 	foo := "foo@example.com"
 
 	// acct owner
@@ -30,15 +29,15 @@ func TestValidateOwnersAccount(t *testing.T) {
 	c := confAcctOwner(foo, foo)
 
 	// Both defaults and acct are set
-	a.Nil(c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString).ErrorOrNil())
+	r.Nil(c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString).ErrorOrNil())
 
 	// defaults unset, still valid
 	c = confAcctOwner("", foo)
-	a.NoError(c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString).ErrorOrNil())
+	r.NoError(c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString).ErrorOrNil())
 
 	// both unset, no longer valid
 	c = confAcctOwner("", "")
-	a.Equal(2, c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString).Len())
+	r.Equal(2, c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString).Len())
 }
 
 func TestValidateOwnersComponent(t *testing.T) {
@@ -63,14 +62,14 @@ func TestValidateOwnersComponent(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.label, func(t *testing.T) {
-			a := assert.New(t)
+			r := require.New(t)
 			c := confComponentOwner(tt.def, tt.env, tt.comp)
 			e := c.validateInheritedStringField("owner", OwnerGetter, nonEmptyString)
 			if tt.errNil {
-				a.NoError(e.ErrorOrNil())
+				r.NoError(e.ErrorOrNil())
 			} else {
-				a.NotNil(e)
-				a.Equal(tt.errz, e.Len())
+				r.NotNil(e)
+				r.Equal(tt.errz, e.Len())
 			}
 		})
 	}
@@ -166,18 +165,19 @@ func confComponentOwner(def, env, component string) Config {
 }
 
 func TestResolveStringArray(t *testing.T) {
+	r := require.New(t)
 	def := []string{"foo"}
 	override := []string{"bar"}
 
 	result := ResolveStringArray(def, override)
-	assert.Len(t, result, 1)
-	assert.Equal(t, "bar", result[0])
+	r.Len(result, 1)
+	r.Equal("bar", result[0])
 
 	override = nil
 
 	result2 := ResolveStringArray(def, override)
-	assert.Len(t, result2, 1)
-	assert.Equal(t, "foo", result2[0])
+	r.Len(result2, 1)
+	r.Equal("foo", result2[0])
 }
 
 func TestConfig_ValidateAWSProviders(t *testing.T) {

--- a/init/init_test.go
+++ b/init/init_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/chanzuckerberg/fogg/config"
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInit(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	project := "acme"
 	region := "us-west-2"
 	bucket := "acme-infra"
@@ -18,16 +18,16 @@ func TestInit(t *testing.T) {
 	profile := "acme-auth"
 	owner := "infra@acme.example"
 	fs, _, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 
 	conf := config.InitConfig(project, region, bucket, table, profile, owner, AWSProviderVersion)
-	a.NotNil(conf)
-	a.Equal(config.DefaultFoggVersion, conf.Version)
+	r.NotNil(conf)
+	r.Equal(config.DefaultFoggVersion, conf.Version)
 
 	err = writeConfig(fs, conf)
-	a.NoError(err)
+	r.NoError(err)
 
 	exists, err := afero.Exists(fs, "fogg.yml")
-	a.NoError(err)
-	a.True(exists)
+	r.NoError(err)
+	r.True(exists)
 }

--- a/plan/ci_test.go
+++ b/plan/ci_test.go
@@ -6,7 +6,7 @@ import (
 
 	v2 "github.com/chanzuckerberg/fogg/config/v2"
 	"github.com/chanzuckerberg/fogg/util"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var id1, id2 json.Number
@@ -22,7 +22,7 @@ func init() {
 }
 
 func Test_buildTravisCI_Disabled(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	{
 		c := &v2.Config{
 			Defaults: v2.Defaults{
@@ -40,13 +40,13 @@ func Test_buildTravisCI_Disabled(t *testing.T) {
 		p := &Plan{}
 		p.Accounts = p.buildAccounts(c)
 		tr := p.buildTravisCIConfig(c, "0.1.0")
-		a.NotNil(tr)
-		a.False(tr.Enabled)
+		r.NotNil(tr)
+		r.False(tr.Enabled)
 	}
 }
 
 func Test_buildTravisCI_Profiles(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	c := &v2.Config{
 		Version: 2,
@@ -86,21 +86,21 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 	}
 
 	w, err := c.Validate()
-	a.NoError(err)
-	a.Len(w, 0)
+	r.NoError(err)
+	r.Len(w, 0)
 
 	p := &Plan{}
 	p.Accounts = p.buildAccounts(c)
 	tr := p.buildTravisCIConfig(c, "0.1.0")
-	a.Len(tr.AWSProfiles, 2)
-	a.Contains(tr.AWSProfiles, "profile")
-	a.Contains(tr.AWSProfiles, "foo")
-	a.Equal(id1.String(), tr.AWSProfiles["foo"].AccountID)
-	a.Equal("rollin", tr.AWSProfiles["foo"].RoleName)
+	r.Len(tr.AWSProfiles, 2)
+	r.Contains(tr.AWSProfiles, "profile")
+	r.Contains(tr.AWSProfiles, "foo")
+	r.Equal(id1.String(), tr.AWSProfiles["foo"].AccountID)
+	r.Equal("rollin", tr.AWSProfiles["foo"].RoleName)
 }
 
 func Test_buildTravisCI_TestBuckets(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	c := &v2.Config{
 		Version: 2,
@@ -142,20 +142,20 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 	}
 
 	w, err := c.Validate()
-	a.NoError(err)
-	a.Len(w, 0)
+	r.NoError(err)
+	r.Len(w, 0)
 
 	p := &Plan{}
 	p.Accounts = p.buildAccounts(c)
 	tr := p.buildTravisCIConfig(c, "0.1.0")
-	a.NotNil(p.Accounts["foo"].Providers.AWS)
-	a.Equal(id1, p.Accounts["foo"].Providers.AWS.AccountID)
-	a.Len(tr.TestBuckets, 1)
-	a.Len(tr.TestBuckets[0], 2)
+	r.NotNil(p.Accounts["foo"].Providers.AWS)
+	r.Equal(id1, p.Accounts["foo"].Providers.AWS.AccountID)
+	r.Len(tr.TestBuckets, 1)
+	r.Len(tr.TestBuckets[0], 2)
 }
 
 func Test_buildCircleCI_Profiles(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	c := &v2.Config{
 		Version: 2,
@@ -195,21 +195,21 @@ func Test_buildCircleCI_Profiles(t *testing.T) {
 	}
 
 	w, err := c.Validate()
-	a.NoError(err)
-	a.Len(w, 0)
+	r.NoError(err)
+	r.Len(w, 0)
 
 	p := &Plan{}
 	p.Accounts = p.buildAccounts(c)
 	circle := p.buildCircleCIConfig(c, "0.1.0")
-	a.Len(circle.AWSProfiles, 2)
-	a.Contains(circle.AWSProfiles, "profile")
-	a.Contains(circle.AWSProfiles, "foo")
-	a.Equal(id1.String(), circle.AWSProfiles["foo"].AccountID)
-	a.Equal("rollin", circle.AWSProfiles["foo"].RoleName)
+	r.Len(circle.AWSProfiles, 2)
+	r.Contains(circle.AWSProfiles, "profile")
+	r.Contains(circle.AWSProfiles, "foo")
+	r.Equal(id1.String(), circle.AWSProfiles["foo"].AccountID)
+	r.Equal("rollin", circle.AWSProfiles["foo"].RoleName)
 }
 
 func Test_buildCircleCI_ProfilesDisabled(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	c := &v2.Config{
 		Version: 2,
@@ -254,11 +254,11 @@ func Test_buildCircleCI_ProfilesDisabled(t *testing.T) {
 	}
 
 	w, err := c.Validate()
-	a.NoError(err)
-	a.Len(w, 0)
+	r.NoError(err)
+	r.Len(w, 0)
 
 	p := &Plan{}
 	p.Accounts = p.buildAccounts(c)
 	circle := p.buildCircleCIConfig(c, "0.1.0")
-	a.Len(circle.AWSProfiles, 0)
+	r.Len(circle.AWSProfiles, 0)
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -21,14 +21,15 @@ func init() {
 
 // func TestResolveRequired(t *testing.T) {
 // 	resolved := resolveRequired("def", nil)
-// 	assert.Equal(t, "def", resolved)
+// 	r.Equal("def", resolved)
 
 // 	over := "over"
 // 	resolved = resolveRequired("def", &over)
-// 	assert.Equal(t, "over", resolved)
+// 	r.Equal("over", resolved)
 // }
 
 func TestResolveAccounts(t *testing.T) {
+	r := require.New(t)
 	foo, bar := json.Number("123"), json.Number("456")
 
 	accounts := map[string]v2.Account{
@@ -54,79 +55,79 @@ func TestResolveAccounts(t *testing.T) {
 	}
 
 	other := resolveAccounts(accounts)
-	assert.NotNil(t, other)
+	r.NotNil(other)
 	var nilJsonNumber *json.Number
-	assert.Equal(t, map[string]*json.Number{"bar": &bar, "foo": &foo, "baz": nilJsonNumber}, other)
+	r.Equal(map[string]*json.Number{"bar": &bar, "foo": &foo, "baz": nilJsonNumber}, other)
 }
 
 func TestPlanBasicV2Yaml(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	b, e := util.TestFile("v2_full_yaml")
-	assert.NoError(t, e)
+	r.NoError(e)
 
 	fs, _, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	err = afero.WriteFile(fs, "fogg.yml", b, 0644)
-	a.NoError(err)
+	r.NoError(err)
 	c2, err := v2.ReadConfig(fs, b, "fogg.yml")
-	assert.Nil(t, err)
+	r.Nil(err)
 
 	w, err := c2.Validate()
-	a.NoError(err)
-	a.Len(w, 0)
+	r.NoError(err)
+	r.Len(w, 0)
 
 	plan, e := Eval(c2)
-	assert.Nil(t, e)
-	assert.NotNil(t, plan)
-	assert.NotNil(t, plan.Accounts)
-	assert.Len(t, plan.Accounts, 2)
+	r.Nil(e)
+	r.NotNil(plan)
+	r.NotNil(plan.Accounts)
+	r.Len(plan.Accounts, 2)
 
-	assert.NotNil(t, plan.Modules)
-	assert.Len(t, plan.Modules, 1)
-	assert.Equal(t, "0.100.0", plan.Modules["my_module"].TerraformVersion)
+	r.NotNil(plan.Modules)
+	r.Len(plan.Modules, 1)
+	r.Equal("0.100.0", plan.Modules["my_module"].TerraformVersion)
 
-	assert.NotNil(t, plan.Envs)
-	assert.Len(t, plan.Envs, 2)
+	r.NotNil(plan.Envs)
+	r.Len(plan.Envs, 2)
 
-	assert.NotNil(t, plan.Envs["staging"])
+	r.NotNil(plan.Envs["staging"])
 
-	assert.NotNil(t, plan.Envs["staging"].Components)
-	assert.Len(t, plan.Envs["staging"].Components, 4)
+	r.NotNil(plan.Envs["staging"].Components)
+	r.Len(plan.Envs["staging"].Components, 4)
 
-	assert.NotNil(t, plan.Envs["staging"])
-	assert.NotNil(t, plan.Envs["staging"].Components["vpc"])
+	r.NotNil(plan.Envs["staging"])
+	r.NotNil(plan.Envs["staging"].Components["vpc"])
 	logrus.Debugf("%#v\n", plan.Envs["staging"].Components["vpc"].ModuleSource)
-	assert.NotNil(t, *plan.Envs["staging"].Components["vpc"].ModuleSource)
-	assert.Equal(t, "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0", *plan.Envs["staging"].Components["vpc"].ModuleSource)
+	r.NotNil(*plan.Envs["staging"].Components["vpc"].ModuleSource)
+	r.Equal("github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0", *plan.Envs["staging"].Components["vpc"].ModuleSource)
 
-	assert.NotNil(t, plan.Envs["staging"].Components["comp1"])
-	assert.Equal(t, "0.100.0", plan.Envs["staging"].Components["comp1"].TerraformVersion)
+	r.NotNil(plan.Envs["staging"].Components["comp1"])
+	r.Equal("0.100.0", plan.Envs["staging"].Components["comp1"].TerraformVersion)
 
-	assert.NotNil(t, plan.Envs["staging"].Components["comp_helm_template"])
-	assert.Equal(t, "k8s", plan.Envs["staging"].Components["comp_helm_template"].EKS.ClusterName)
+	r.NotNil(plan.Envs["staging"].Components["comp_helm_template"])
+	r.Equal("k8s", plan.Envs["staging"].Components["comp_helm_template"].EKS.ClusterName)
 
-	assert.NotNil(t, plan.Envs["prod"])
-	assert.NotNil(t, plan.Envs["prod"].Components["hero"])
-	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers)
-	assert.NotNil(t, plan.Envs["prod"].Components["hero"].Providers.Heroku)
+	r.NotNil(plan.Envs["prod"])
+	r.NotNil(plan.Envs["prod"].Components["hero"])
+	r.NotNil(plan.Envs["prod"].Components["hero"].Providers)
+	r.NotNil(plan.Envs["prod"].Components["hero"].Providers.Heroku)
 
-	assert.NotNil(t, plan.Envs["prod"])
-	assert.NotNil(t, plan.Envs["prod"].Components["datadog"])
-	assert.NotNil(t, plan.Envs["prod"].Components["datadog"].Providers)
-	assert.NotNil(t, plan.Envs["prod"].Components["datadog"].Providers.Datadog)
+	r.NotNil(plan.Envs["prod"])
+	r.NotNil(plan.Envs["prod"].Components["datadog"])
+	r.NotNil(plan.Envs["prod"].Components["datadog"].Providers)
+	r.NotNil(plan.Envs["prod"].Components["datadog"].Providers.Datadog)
 
 	// accts inherit defaults
-	assert.Equal(t, "bar1", plan.Accounts["foo"].ExtraVars["foo"])
+	r.Equal("bar1", plan.Accounts["foo"].ExtraVars["foo"])
 	// envs overwrite defaults
-	assert.Equal(t, "bar2", plan.Envs["staging"].Components["comp1"].ExtraVars["foo"])
+	r.Equal("bar2", plan.Envs["staging"].Components["comp1"].ExtraVars["foo"])
 	// component overwrite env
-	assert.Equal(t, "bar3", plan.Envs["staging"].Components["vpc"].ExtraVars["foo"])
+	r.Equal("bar3", plan.Envs["staging"].Components["vpc"].ExtraVars["foo"])
 }
 
 func TestResolveEKSConfig(t *testing.T) {
-	a := assert.New(t)
-	a.Equal("", resolveEKSConfig(nil, nil).ClusterName)
-	a.Equal("a", resolveEKSConfig(&v2.EKSConfig{ClusterName: "a"}, nil).ClusterName)
-	a.Equal("b", resolveEKSConfig(&v2.EKSConfig{ClusterName: "a"}, &v2.EKSConfig{ClusterName: "b"}).ClusterName)
+	r := require.New(t)
+	r.Equal("", resolveEKSConfig(nil, nil).ClusterName)
+	r.Equal("a", resolveEKSConfig(&v2.EKSConfig{ClusterName: "a"}, nil).ClusterName)
+	r.Equal("b", resolveEKSConfig(&v2.EKSConfig{ClusterName: "a"}, &v2.EKSConfig{ClusterName: "b"}).ClusterName)
 }

--- a/plugins/custom_plugin_test.go
+++ b/plugins/custom_plugin_test.go
@@ -18,19 +18,18 @@ import (
 	"github.com/chanzuckerberg/fogg/plugins"
 	"github.com/chanzuckerberg/fogg/util"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCustomPluginTar(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	pluginName := "test-provider"
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	cacheDir, err := ioutil.TempDir("", "")
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
 
@@ -38,11 +37,11 @@ func TestCustomPluginTar(t *testing.T) {
 	tarPath := generateTar(t, files, nil)
 	defer os.Remove(tarPath)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		f, err := os.Open(tarPath)
-		a.Nil(err)
+		r.Nil(err)
 		_, err = io.Copy(w, f)
-		a.Nil(err)
+		r.Nil(err)
 	}))
 	defer ts.Close()
 
@@ -51,35 +50,35 @@ func TestCustomPluginTar(t *testing.T) {
 		Format: plugins.TypePluginFormatTar,
 	}
 	customPlugin.WithTargetPath(plugins.CustomPluginDir).WithCache(cache)
-	a.Nil(customPlugin.Install(fs, pluginName))
+	r.Nil(customPlugin.Install(fs, pluginName))
 
-	a.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
-		a.Nil(err)
+	r.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
+		r.Nil(err)
 		return nil
 	}))
 
 	for _, file := range files {
 		filePath := path.Join(plugins.CustomPluginDir, file)
 		fi, err := fs.Stat(filePath)
-		a.Nil(err)
-		a.False(fi.IsDir())
-		a.Equal(fi.Mode(), os.FileMode(0755))
+		r.Nil(err)
+		r.False(fi.IsDir())
+		r.Equal(fi.Mode(), os.FileMode(0755))
 
 		bytes, err := afero.ReadFile(fs, filePath)
-		a.Nil(err)
-		a.Equal(bytes, []byte(file)) // We wrote the filename as the contents as well
+		r.Nil(err)
+		r.Equal(bytes, []byte(file)) // We wrote the filename as the contents as well
 	}
 }
 
 func TestCustomPluginTarStripComponents(t *testing.T) {
-	a := require.New(t)
+	r := require.New(t)
 	pluginName := "test-provider"
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	cacheDir, err := ioutil.TempDir("", "")
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
 
@@ -89,11 +88,11 @@ func TestCustomPluginTarStripComponents(t *testing.T) {
 	tarPath := generateTar(t, files, dirs)
 	defer os.Remove(tarPath)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		f, err := os.Open(tarPath)
-		a.Nil(err)
+		r.Nil(err)
 		_, err = io.Copy(w, f)
-		a.Nil(err)
+		r.Nil(err)
 	}))
 	defer ts.Close()
 
@@ -105,10 +104,10 @@ func TestCustomPluginTarStripComponents(t *testing.T) {
 		},
 	}
 	customPlugin.WithTargetPath(plugins.CustomPluginDir).WithCache(cache)
-	a.Nil(customPlugin.Install(fs, pluginName))
+	r.Nil(customPlugin.Install(fs, pluginName))
 
-	a.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
-		a.Nil(err)
+	r.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
+		r.Nil(err)
 		return nil
 	}))
 
@@ -117,30 +116,30 @@ func TestCustomPluginTarStripComponents(t *testing.T) {
 		if file == "" {
 			filePath := path.Join(plugins.CustomPluginDir, files[idx])
 			_, err := fs.Stat(filePath)
-			a.NotNil(err)
-			a.True(os.IsNotExist(err))
+			r.NotNil(err)
+			r.True(os.IsNotExist(err))
 			continue
 		}
 		filePath := path.Join(plugins.CustomPluginDir, file)
 		fi, err := fs.Stat(filePath)
-		a.Nil(err)
-		a.False(fi.IsDir())
-		a.Equal(fi.Mode(), os.FileMode(0755))
+		r.Nil(err)
+		r.False(fi.IsDir())
+		r.Equal(fi.Mode(), os.FileMode(0755))
 
 		bytes, err := afero.ReadFile(fs, filePath)
-		a.Nil(err)
-		a.Equal(bytes, []byte(files[idx])) // We wrote the filename as the contents as well
+		r.Nil(err)
+		r.Equal(bytes, []byte(files[idx])) // We wrote the filename as the contents as well
 	}
 }
 func TestCustomPluginZip(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	pluginName := "test-provider"
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 
 	cacheDir, err := ioutil.TempDir("", "")
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
 
@@ -148,11 +147,11 @@ func TestCustomPluginZip(t *testing.T) {
 	zipPath := generateZip(t, files)
 	defer os.Remove(zipPath)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		f, err := os.Open(zipPath)
-		a.Nil(err)
+		r.Nil(err)
 		_, err = io.Copy(w, f)
-		a.Nil(err)
+		r.Nil(err)
 	}))
 	defer ts.Close()
 
@@ -161,42 +160,42 @@ func TestCustomPluginZip(t *testing.T) {
 		Format: plugins.TypePluginFormatZip,
 	}
 	customPlugin.WithTargetPath(plugins.CustomPluginDir).WithCache(cache)
-	a.Nil(customPlugin.Install(fs, pluginName))
+	r.Nil(customPlugin.Install(fs, pluginName))
 
-	a.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
-		a.Nil(err)
+	r.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
+		r.Nil(err)
 		return nil
 	}))
 
 	for _, file := range files {
 		filePath := path.Join(plugins.CustomPluginDir, file)
 		fi, err := fs.Stat(filePath)
-		a.Nil(err)
-		a.False(fi.IsDir())
-		a.Equal(fi.Mode(), os.FileMode(0755))
+		r.Nil(err)
+		r.False(fi.IsDir())
+		r.Equal(fi.Mode(), os.FileMode(0755))
 
 		bytes, err := afero.ReadFile(fs, filePath)
-		a.Nil(err)
-		a.Equal(bytes, []byte(file)) // We wrote the filename as the contents as well
+		r.Nil(err)
+		r.Equal(bytes, []byte(file)) // We wrote the filename as the contents as well
 	}
 }
 
 func TestCustomPluginBin(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	pluginName := "test-provider"
 	fs, d, err := util.TestFs()
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(d)
 	fileContents := "some contents"
 
 	cacheDir, err := ioutil.TempDir("", "")
-	a.NoError(err)
+	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		_, err := fmt.Fprint(w, fileContents)
-		a.Nil(err)
+		r.Nil(err)
 	}))
 	defer ts.Close()
 
@@ -206,35 +205,35 @@ func TestCustomPluginBin(t *testing.T) {
 	}
 
 	customPlugin.WithTargetPath(plugins.TerraformCustomPluginCacheDir).WithCache(cache)
-	a.Nil(customPlugin.Install(fs, pluginName))
+	r.Nil(customPlugin.Install(fs, pluginName))
 
-	a.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
-		a.Nil(err)
+	r.NoError(afero.Walk(fs, "", func(path string, info os.FileInfo, err error) error {
+		r.Nil(err)
 		return nil
 	}))
 
 	// Make sure we properly template
 	pluginDir, err := plugins.Template(plugins.TerraformCustomPluginCacheDir, runtime.GOOS, runtime.GOARCH)
-	a.NoError(err)
+	r.NoError(err)
 	customPluginPath := path.Join(pluginDir, pluginName)
 	f, err := fs.Open(customPluginPath)
-	a.Nil(err)
+	r.Nil(err)
 
 	contents, err := ioutil.ReadAll(f)
-	a.Nil(err)
-	a.Equal(string(contents), fileContents)
+	r.Nil(err)
+	r.Equal(string(contents), fileContents)
 
 	fi, err := fs.Stat(customPluginPath)
-	a.Nil(err)
-	a.False(fi.IsDir())
-	a.Equal(os.FileMode(0755), fi.Mode().Perm())
+	r.Nil(err)
+	r.False(fi.IsDir())
+	r.Equal(os.FileMode(0755), fi.Mode().Perm())
 }
 
 func generateTar(t *testing.T, files []string, dirs []string) string {
-	a := assert.New(t)
+	r := require.New(t)
 
 	f, err := ioutil.TempFile("", "testing")
-	a.Nil(err)
+	r.Nil(err)
 	defer f.Close()
 	gw := gzip.NewWriter(f)
 	defer gw.Close()
@@ -248,7 +247,7 @@ func generateTar(t *testing.T, files []string, dirs []string) string {
 		header.Mode = int64(0777)
 		header.Typeflag = tar.TypeDir
 
-		a.Nil(tw.WriteHeader(header))
+		r.Nil(tw.WriteHeader(header))
 	}
 
 	for _, file := range files {
@@ -258,9 +257,9 @@ func generateTar(t *testing.T, files []string, dirs []string) string {
 		header.Mode = int64(0755)
 		header.Typeflag = tar.TypeReg
 
-		a.Nil(tw.WriteHeader(header))
+		r.Nil(tw.WriteHeader(header))
 		_, err = fmt.Fprintf(tw, file)
-		a.Nil(err)
+		r.Nil(err)
 	}
 
 	return f.Name()
@@ -268,9 +267,9 @@ func generateTar(t *testing.T, files []string, dirs []string) string {
 
 // based on https://golangcode.com/create-zip-files-in-go/
 func generateZip(t *testing.T, files []string) string {
-	a := assert.New(t)
+	r := require.New(t)
 	f, err := ioutil.TempFile("", "testing")
-	a.Nil(err)
+	r.Nil(err)
 
 	defer f.Close()
 
@@ -284,9 +283,9 @@ func generateZip(t *testing.T, files []string) string {
 		}
 		header.SetMode(os.FileMode(0755))
 		writer, err := zipWriter.CreateHeader(header)
-		a.Nil(err)
+		r.Nil(err)
 		_, err = io.Copy(writer, strings.NewReader(file))
-		a.Nil(err)
+		r.Nil(err)
 	}
 	return f.Name()
 }

--- a/util/module_storage_test.go
+++ b/util/module_storage_test.go
@@ -8,37 +8,37 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDownloadModule(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 	dir, e := ioutil.TempDir("", "fogg")
-	assert.Nil(t, e)
+	r.Nil(e)
 
 	pwd, e := os.Getwd()
-	a.NoError(e)
+	r.NoError(e)
 
 	fs := afero.NewBasePathFs(afero.NewOsFs(), pwd)
 	d, e := DownloadModule(fs, dir, "github.com/chanzuckerberg/fogg-test-module")
-	a.NoError(e)
-	a.NotNil(d)
-	a.NotEmpty(d)
+	r.NoError(e)
+	r.NotNil(d)
+	r.NotEmpty(d)
 	// TODO more asserts
 }
 
 func TestDownloadAndParseModule(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	pwd, e := os.Getwd()
-	a.NoError(e)
+	r.NoError(e)
 	fs := afero.NewBasePathFs(afero.NewOsFs(), pwd)
 
 	c, e := DownloadAndParseModule(fs, "github.com/chanzuckerberg/fogg-test-module")
-	assert.Nil(t, e)
-	assert.NotNil(t, c)
-	assert.NotNil(t, c.Variables)
-	assert.NotNil(t, c.Outputs)
-	assert.Len(t, c.Variables, 2)
-	assert.Len(t, c.Outputs, 2)
+	r.Nil(e)
+	r.NotNil(c)
+	r.NotNil(c.Variables)
+	r.NotNil(c.Outputs)
+	r.Len(c.Variables, 2)
+	r.Len(c.Outputs, 2)
 }

--- a/util/version_test.go
+++ b/util/version_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParse(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	testCases := []struct {
 		input   string
@@ -24,10 +24,10 @@ func TestParse(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			v, sha, dirty := ParseVersion(tc.input)
 			semVersion, e := semver.Parse(tc.version)
-			a.NoError(e)
-			a.Equal(semVersion, v)
-			a.Equal(tc.sha, sha)
-			a.Equal(tc.dirty, dirty)
+			r.NoError(e)
+			r.Equal(semVersion, v)
+			r.Equal(tc.sha, sha)
+			r.Equal(tc.dirty, dirty)
 		})
 	}
 


### PR DESCRIPTION
We have been slowly doing this, but that has been creating a fair amount
of confusion.

We prefer require over assert because assert does not stop when it
fails, while require does. I have found that this is what people expect
from testing assertions.

### Test Plan
* ci

### References
* https://godoc.org/github.com/stretchr/testify/assert
* https://godoc.org/github.com/stretchr/testify/require