### PR TITLE
[fix] CI provider aws value configuration

### DIFF
--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -277,16 +277,23 @@ func ResolveCircleCI(commons ...Common) *CircleCI {
 	enabled := false
 	buildevents := false
 	testCommand := "check"
+	var providers map[string]CIProviderConfig
 
 	for _, c := range commons {
 		if c.Tools != nil && c.Tools.CircleCI != nil && c.Tools.CircleCI.Enabled != nil {
 			enabled = *c.Tools.CircleCI.Enabled
 		}
+
 		if c.Tools != nil && c.Tools.CircleCI != nil && c.Tools.CircleCI.Command != nil {
 			testCommand = *c.Tools.CircleCI.Command
 		}
+
 		if c.Tools != nil && c.Tools.CircleCI != nil && c.Tools.CircleCI.Buildevents != nil {
 			buildevents = *c.Tools.CircleCI.Buildevents
+		}
+
+		if c.Tools != nil && c.Tools.CircleCI != nil {
+			providers = c.Tools.CircleCI.Providers
 		}
 	}
 
@@ -299,6 +306,7 @@ func ResolveCircleCI(commons ...Common) *CircleCI {
 			Buildevents:    &buildevents,
 			AWSIAMRoleName: roleName,
 			Command:        &testCommand,
+			Providers:      providers,
 		},
 		SSHKeyFingerprints: sshFingerprints,
 	}


### PR DESCRIPTION
### Summary
Couple of issues.
1. provider CI values are not parsed so we always use default values.
2. When default value for CI provider aws is disabled, we are resetting all the providers.

### Test Plan
Ran the following tests locally.
1. set default to (disabled:true) and none of accounts/envs are configured - Made sure we don't generate CI config for all of them.
2. set default to (disabled:false) and none of accounts/envs are configured - Made sure we do generate CI config for all of them.
3. set default to (disabled:true) and only 1 account has disabled:false - Made sure only that account has config generated.
4. Did the above test for env.
5. Verified by not configuring default values and account/env values takes precedence.

### References
(Optional) Additional links to provide more context.