### PR TITLE
[feature] Disable Docker releases

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -13,7 +13,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - "-w -s -X github.com/chanzuckerberg/fogg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/fogg/util.Version={{.Version}} -X github.com/chanzuckerberg/fogg/util.Dirty=false -X github.com/chanzuckerberg/fogg/util.Release=true"
+      - '-w -s -X github.com/chanzuckerberg/fogg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/fogg/util.Version={{.Version}} -X github.com/chanzuckerberg/fogg/util.Dirty=false -X github.com/chanzuckerberg/fogg/util.Release=true'
 
 archives:
   - files:
@@ -21,31 +21,6 @@ archives:
 
 release:
   prerelease: true
-
-# image_template uses .ShortCommit for a unique tag that fits semver's guidelines and docker tagging requirements
-# We use .Version for .goreleaser.yml
-dockers:
-  - dockerfile: Dockerfile
-    image_templates:
-      - docker.pkg.github.com/chanzuckerberg/fogg/fogg:{{.ShortCommit}}
-    extra_files:
-      - cmd
-      - go.mod
-      - go.sum
-      - main.go
-      - vendor
-      - apply
-      - config
-      - docs
-      - errs
-      - exp
-      - init
-      - migrations
-      - plan
-      - plugins
-      - setup
-      - templates
-      - util
 
 env_files:
   github_token: ~/.config/goreleaser/github_token

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - "-w -s -X github.com/chanzuckerberg/fogg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/fogg/util.Version={{.Version}} -X github.com/chanzuckerberg/fogg/util.Dirty=false -X github.com/chanzuckerberg/fogg/util.Release=true"
+      - '-w -s -X github.com/chanzuckerberg/fogg/util.GitSha={{.Commit}} -X github.com/chanzuckerberg/fogg/util.Version={{.Version}} -X github.com/chanzuckerberg/fogg/util.Dirty=false -X github.com/chanzuckerberg/fogg/util.Release=true'
 
 archives:
   - files:
@@ -23,34 +23,11 @@ release:
   prerelease: false
 
 brews:
-  - description: "Terraform without pain."
+  - description: 'Terraform without pain.'
     github:
       owner: chanzuckerberg
       name: homebrew-tap
-    homepage: "https://github.com/chanzuckerberg/fogg"
+    homepage: 'https://github.com/chanzuckerberg/fogg'
     test: system "#{bin}/fogg version"
-
-dockers:
-  - dockerfile: Dockerfile
-    image_templates:
-      - docker.pkg.github.com/chanzuckerberg/fogg/fogg:v{{.Version}}
-    extra_files:
-      - cmd
-      - go.mod
-      - go.sum
-      - main.go
-      - vendor
-      - apply
-      - config
-      - docs
-      - errs
-      - exp
-      - init
-      - migrations
-      - plan
-      - plugins
-      - setup
-      - templates
-      - util
 env_files:
   github_token: ~/.config/goreleaser/github_token


### PR DESCRIPTION
No one has ever downloaded any fogg docker image from GitHub registry. Might as well get rid of them and speed up our builds.