### PR TITLE
[fix] error when we encounter an unknown field

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"bytes"
 	"encoding/json"
 	"math/rand"
 	"path/filepath"
@@ -28,7 +29,10 @@ func ReadConfig(fs afero.Fs, b []byte, configFile string) (*Config, error) {
 	//Determines the file extension
 	switch ext {
 	case ".yml", ".yaml":
-		e = yaml.Unmarshal(b, c)
+		reader := bytes.NewReader(b)
+		decoder := yaml.NewDecoder(reader)
+		decoder.KnownFields(true)
+		e = decoder.Decode(c)
 	default:
 		return nil, errs.NewUserf("File type %s is not supported", ext)
 	}

--- a/testdata/bless_provider_yaml/fogg.yml
+++ b/testdata/bless_provider_yaml/fogg.yml
@@ -19,11 +19,10 @@ defaults:
 envs:
   bar:
     components:
-      bam: 
-        eks: 
+      bam:
+        eks:
           cluster_name: foo
-          kind: bar
 modules:
-  foo: 
+  foo:
     terraform_version: 1.1.1
 version: 2

--- a/testdata/snowflake_provider_yaml/fogg.yml
+++ b/testdata/snowflake_provider_yaml/fogg.yml
@@ -17,11 +17,10 @@ envs:
   bar:
     components:
       bam:
-        eks: 
+        eks:
           cluster_name: foo
-          kind: bar
 modules:
-  foo: 
+  foo:
     terraform_version: 1.1.1
-        
+
 version: 2


### PR DESCRIPTION
This change will cause fogg to throw an error whenever it encounters an
unknown field in the yaml configuration.

### Test Plan
* CI

### References
* https://godoc.org/gopkg.in/yaml.v3#Decoder.KnownFields