### PR TITLE
[refactor] aws provider into common template

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -124,12 +124,11 @@ type Providers struct {
 
 //AWSProvider represents AWS provider configuration
 type AWSProvider struct {
-	AccountID         json.Number `yaml:"account_id"`
-	AdditionalRegions []string    `yaml:"additional_regions"`
-	Alias             *string     `yaml:"alias"`
-	Profile           string      `yaml:"profile"`
-	Region            string      `yaml:"region"`
-	Version           string      `yaml:"version"`
+	AccountID json.Number `yaml:"account_id"`
+	Alias     *string     `yaml:"alias"`
+	Profile   string      `yaml:"profile"`
+	Region    string      `yaml:"region"`
+	Version   string      `yaml:"version"`
 }
 
 // GithubProvider represents a configuration of a github provider
@@ -450,13 +449,15 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		}
 
 		for _, r := range awsConfig.AdditionalRegions {
+			// we have to take a reference here otherwise it gets overwritten by the loop
+			region := r
 			additionalProviders = append(additionalProviders,
 				AWSProvider{
 					AccountID: *awsConfig.AccountID,
-					Alias:     &r,
+					Alias:     &region,
 					Profile:   *awsConfig.Profile,
 					Version:   *awsConfig.Version,
-					Region:    *awsConfig.Region,
+					Region:    region,
 				})
 		}
 	}

--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -4,7 +4,6 @@
 {{if .Providers.AWS}}
 {{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
-  {{ $outer := . -}}
   {{ range $p := .Providers.AWSAdditionalProviders }}
     {{ template "aws_provider" $p}}
   {{ end }}

--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -5,14 +5,8 @@
 {{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
   {{ $outer := . -}}
-  {{ range $region := .Providers.AWS.AdditionalRegions }}
-    provider aws {
-      alias = "{{ $region }}"
-      version = "~> {{ $outer.Providers.AWS.Version }}"
-      region = "{{ $region }}"
-      profile = "{{ $outer.Providers.AWS.Profile }}"
-      allowed_account_ids = [{{ $outer.Providers.AWS.AccountID }}]
-    }
+  {{ range $p := .Providers.AWSAdditionalProviders }}
+    {{ template "aws_provider" $p}}
   {{ end }}
 {{ end }}
 

--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -2,14 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 {{if .Providers.AWS}}
-  # Default Provider
-  provider aws {
-    version = "~> {{ .Providers.AWS.Version }}"
-    region = "{{ .Providers.AWS.Region }}"
-    profile = "{{ .Providers.AWS.Profile }}"
-    allowed_account_ids = [{{ .Providers.AWS.AccountID }}]
-  }
-
+{{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
   {{ $outer := . -}}
   {{ range $region := .Providers.AWS.AdditionalRegions }}

--- a/templates/common/aws_provider.tmpl
+++ b/templates/common/aws_provider.tmpl
@@ -1,0 +1,8 @@
+{{ define "aws_provider" }}
+provider aws {
+  version = "~> {{ .Version }}"
+  region = "{{ .Region }}"
+  profile = "{{ .Profile }}"
+  allowed_account_ids = [{{ .AccountID }}]
+}
+{{ end }}

--- a/templates/common/aws_provider.tmpl
+++ b/templates/common/aws_provider.tmpl
@@ -1,5 +1,6 @@
 {{ define "aws_provider" }}
 provider aws {
+  {{ if .Alias }}alias = "{{ .Alias }}"{{ end }}
   version = "~> {{ .Version }}"
   region = "{{ .Region }}"
   profile = "{{ .Profile }}"

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -4,15 +4,8 @@
 {{ if .Providers.AWS }}
 {{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
-  {{ $outer := . }}
-  {{ range $region := .Providers.AWS.AdditionalRegions }}
-    provider aws {
-      alias = "{{ $region }}"
-      version = "~> {{ $outer.Providers.AWS.Version }}"
-      region = "{{ $region }}"
-      profile = "{{ $outer.Providers.AWS.Profile }}"
-      allowed_account_ids = [{{ $outer.Providers.AWS.AccountID }}]
-    }
+  {{ range $p := .Providers.AWSAdditionalProviders }}
+    {{ template "aws_provider" $p}}
   {{ end }}
 
 {{ end }}

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -2,13 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 {{ if .Providers.AWS }}
-  provider aws {
-    version = "~> {{ .Providers.AWS.Version }}"
-    region = "{{ .Providers.AWS.Region }}"
-    profile = "{{ .Providers.AWS.Profile }}"
-    allowed_account_ids = [{{ .Providers.AWS.AccountID }}]
-  }
-
+{{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
   {{ $outer := . }}
   {{ range $region := .Providers.AWS.AdditionalRegions }}

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -2,13 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 {{ if .Providers.AWS }}
-  provider aws {
-    version = "~> {{ .Providers.AWS.Version }}"
-    region = "{{ .Providers.AWS.Region }}"
-    profile = "{{ .Providers.AWS.Profile }}"
-    {{ if .Providers.AWS.AccountID }}allowed_account_ids = [{{ .Providers.AWS.AccountID }}]{{ end }}
-  }
-
+{{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
   {{ $p := .Providers.AWS }}
   {{ range $region := .Providers.AWS.AdditionalRegions }}

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -4,17 +4,9 @@
 {{ if .Providers.AWS }}
 {{ template "aws_provider" .Providers.AWS}}
   # Aliased Providers (for doing things in every region).
-  {{ $p := .Providers.AWS }}
-  {{ range $region := .Providers.AWS.AdditionalRegions }}
-    provider aws {
-      alias = "{{ $region }}"
-      version = "~> {{ $p.Version }}"
-      region = "{{ $region }}"
-      profile = "{{ $p.Profile }}"
-      {{ if $p.AccountID }}allowed_account_ids = [{{ $p.AccountID }}]{{ end }}
-    }
-  {{ end }}
-{{ end }}
+  {{ range $p := .Providers.AWSAdditionalProviders }}
+    {{ template "aws_provider" $p}}
+  {{ end }}{{ end }}
 
 {{ if .Providers.Snowflake }}
   {{ template "snowflake_provider" .Providers.Snowflake }}

--- a/testdata/v2_full_yaml/fogg.yml
+++ b/testdata/v2_full_yaml/fogg.yml
@@ -3,6 +3,9 @@ accounts:
     providers:
       aws:
         account_id: 456
+        additional_regions:
+          - us-east-1
+          - us-east-2
   foo:
     providers:
       aws:

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"
@@ -11,6 +12,26 @@ provider aws {
 }
 
 # Aliased Providers (for doing things in every region).
+
+
+provider aws {
+  alias               = "us-east-2"
+  version             = "~> 0.12.0"
+  region              = "us-west-2"
+  profile             = "profile"
+  allowed_account_ids = [456]
+}
+
+
+
+provider aws {
+  alias               = "us-east-2"
+  version             = "~> 0.12.0"
+  region              = "us-west-2"
+  profile             = "profile"
+  allowed_account_ids = [456]
+}
+
 
 
 

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -2,7 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
-# Default Provider
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -15,9 +15,9 @@ provider aws {
 
 
 provider aws {
-  alias               = "us-east-2"
+  alias               = "us-east-1"
   version             = "~> 0.12.0"
-  region              = "us-west-2"
+  region              = "us-east-1"
   profile             = "profile"
   allowed_account_ids = [456]
 }
@@ -27,7 +27,7 @@ provider aws {
 provider aws {
   alias               = "us-east-2"
   version             = "~> 0.12.0"
-  region              = "us-west-2"
+  region              = "us-east-2"
   profile             = "profile"
   allowed_account_ids = [456]
 }

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -2,7 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
-# Default Provider
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -2,6 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -28,7 +28,6 @@ provider aws {
 
 
 
-
 provider datadog {
 }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -26,7 +26,6 @@ provider aws {
 
 
 
-
 provider heroku {
 }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -2,6 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -2,6 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -31,7 +31,6 @@ provider aws {
 
 
 
-
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -2,6 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -31,7 +31,6 @@ provider aws {
 
 
 
-
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -2,6 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -31,7 +31,6 @@ provider aws {
 
 
 
-
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -28,8 +28,6 @@ provider aws {
 
 
 
-
-
 terraform {
   required_version = "~>0.100.0"
 

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -2,6 +2,7 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 
+
 provider aws {
   version             = "~> 0.12.0"
   region              = "us-west-2"

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -4,6 +4,7 @@
 
 
 provider aws {
+
   version             = "~> 0.12.0"
   region              = "us-west-2"
   profile             = "profile"


### PR DESCRIPTION
Refactor our aws provider configurations in to a common template that is shared across global, accounts and components.

Also push the logic for generating per-region providers from the templates to the planning stage.

### Test Plan
* [x] CI
* [X] tested on 1 internal repo

### References