### PR TITLE
[fix] simplify and optimize .terraformignore

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -22,7 +22,6 @@ type Plan struct {
 	CircleCI        CircleCIConfig        `yaml:"github_actions_ci"`
 	GitHubActionsCI GitHubActionsCIConfig `yaml:"circle_ci"`
 	Version         string                `yaml:"version"`
-	TerraformIgnore []string              `yaml:"terraform_ignore"`
 }
 
 // Common represents common fields
@@ -280,7 +279,6 @@ func Eval(c *v2.Config) (*Plan, error) {
 	p.TravisCI = p.buildTravisCIConfig(c, v)
 	p.CircleCI = p.buildCircleCIConfig(c, v)
 	p.GitHubActionsCI = p.buildGitHubActionsConfig(c, v)
-	p.TerraformIgnore = p.buildTerraformIgnore()
 
 	return p, nil
 }
@@ -679,28 +677,4 @@ func resolveAccounts(accounts map[string]v2.Account) map[string]*json.Number {
 		a[name] = acctID
 	}
 	return a
-}
-
-func (p *Plan) buildTerraformIgnore() []string {
-	// start with a static list that applies to every repository
-	ignores := []string{
-		".git/",
-		".fogg/",
-		".terraform.d/",
-		"terraform/global/.terraform/plugins/",
-	}
-
-	for a := range p.Accounts {
-		ignores = append(ignores, fmt.Sprintf("terraform/accounts/%s/.terraform/plugins/", a))
-	}
-
-	for envName, env := range p.Envs {
-		for componentName, component := range env.Components {
-			if component.Kind.GetOrDefault() == v2.ComponentKindTerraform {
-				ignores = append(ignores, fmt.Sprintf("terraform/envs/%s/%s/.terraform/plugins/", envName, componentName))
-			}
-		}
-	}
-
-	return ignores
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -176,30 +176,6 @@ func buildPlan(t *testing.T, testfile string) *Plan {
 	return plan
 }
 
-func Test_buildTerraformIgnore(t *testing.T) {
-	r := require.New(t)
-
-	p := buildPlan(t, "v2_full_yaml")
-
-	r.NotNil(p)
-
-	expected := []string{
-		".git/",
-		".fogg/",
-		".terraform.d/",
-		"terraform/global/.terraform/plugins/",
-		"terraform/accounts/foo/.terraform/plugins/",
-		"terraform/accounts/bar/.terraform/plugins/",
-		"terraform/envs/prod/hero/.terraform/plugins/",
-		"terraform/envs/prod/datadog/.terraform/plugins/",
-		"terraform/envs/staging/comp1/.terraform/plugins/",
-		"terraform/envs/staging/comp2/.terraform/plugins/",
-		"terraform/envs/staging/vpc/.terraform/plugins/",
-	}
-
-	r.ElementsMatch(expected, p.TerraformIgnore)
-}
-
 func TestTfeProvider(t *testing.T) {
 	r := require.New(t)
 

--- a/templates/repo/.terraformignore.tmpl
+++ b/templates/repo/.terraformignore.tmpl
@@ -1,4 +1,7 @@
 {{ template "fogg_header" }}
-{{ range $i := .TerraformIgnore | sortAlpha }}
-{{ $i }}{{ end }}
 
+.fogg/
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/bless_provider_yaml/.terraformignore
+++ b/testdata/bless_provider_yaml/.terraformignore
@@ -3,9 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/accounts/foo/.terraform/plugins/
-terraform/envs/bar/bam/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/circleci/.terraformignore
+++ b/testdata/circleci/.terraformignore
@@ -3,7 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/github_actions/.terraformignore
+++ b/testdata/github_actions/.terraformignore
@@ -3,7 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/github_provider_yaml/.terraformignore
+++ b/testdata/github_provider_yaml/.terraformignore
@@ -3,9 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/accounts/foo/.terraform/plugins/
-terraform/envs/bar/bam/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/okta_provider_yaml/.terraformignore
+++ b/testdata/okta_provider_yaml/.terraformignore
@@ -3,9 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/accounts/foo/.terraform/plugins/
-terraform/envs/bar/bam/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/snowflake_provider_yaml/.terraformignore
+++ b/testdata/snowflake_provider_yaml/.terraformignore
@@ -3,9 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/accounts/foo/.terraform/plugins/
-terraform/envs/bar/bam/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/tfe_provider_yaml/.terraformignore
+++ b/testdata/tfe_provider_yaml/.terraformignore
@@ -3,9 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/accounts/foo/.terraform/plugins/
-terraform/envs/bar/bam/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/v2_full_yaml/.terraformignore
+++ b/testdata/v2_full_yaml/.terraformignore
@@ -3,14 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/accounts/bar/.terraform/plugins/
-terraform/accounts/foo/.terraform/plugins/
-terraform/envs/prod/datadog/.terraform/plugins/
-terraform/envs/prod/hero/.terraform/plugins/
-terraform/envs/staging/comp1/.terraform/plugins/
-terraform/envs/staging/comp2/.terraform/plugins/
-terraform/envs/staging/vpc/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/v2_minimal_valid_yaml/.terraformignore
+++ b/testdata/v2_minimal_valid_yaml/.terraformignore
@@ -3,7 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**

--- a/testdata/v2_no_aws_provider_yaml/.terraformignore
+++ b/testdata/v2_no_aws_provider_yaml/.terraformignore
@@ -3,8 +3,7 @@
 
 
 .fogg/
-.git/
-.terraform.d/
-terraform/envs/staging/vpc/.terraform/plugins/
-terraform/global/.terraform/plugins/
-
+**/terraform.d/**
+**/.terraform.d/**
+**/.terraform/**
+**/.git/**


### PR DESCRIPTION
Make the configuration simpler and 10x faster at building slugs.

This is faster because the process seems to be CPU bound when you have a
large number of patterns in your .terraformignore.

And slug sizes are smaller because we now exclude modules directorties.

### Summary
A description of changes or issues addressed by this PR. Provide links to relevant PRs if any.

### Test Plan

Tested on shared-infra and runtime when from 6m -> 12s and slug size
from 75MB to 5MB.


### References
* library that builds the slugs - https://github.com/hashicorp/go-slug