### PR TITLE
[feature] Okta Provider: Allow specifying base url

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -123,6 +123,7 @@ type OktaProvider struct {
 	// the okta provider is optional (above) but if supplied you must set an OrgName
 	OrgName *string `yaml:"org_name,omitempty"`
 	Version *string `yaml:"version,omitempty"`
+	BaseURL *string `yaml:"base_url,omitempty"`
 }
 
 // BlessProvider allows for terraform-provider-bless configuration

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -237,6 +237,7 @@ func ResolveSnowflakeProvider(commons ...Common) *SnowflakeProvider {
 
 func ResolveOktaProvider(commons ...Common) *OktaProvider {
 	orgName := lastNonNil(OktaProviderOrgNameGetter, commons...)
+	baseURL := lastNonNil(OktaProviderBaseURLGetter, commons...)
 
 	// required fields
 	if orgName == nil {
@@ -246,6 +247,7 @@ func ResolveOktaProvider(commons ...Common) *OktaProvider {
 	return &OktaProvider{
 		OrgName: orgName,
 		Version: lastNonNil(OktaProviderVersionGetter, commons...),
+		BaseURL: baseURL,
 	}
 }
 
@@ -632,6 +634,13 @@ func OktaProviderVersionGetter(comm Common) *string {
 		return nil
 	}
 	return comm.Providers.Okta.Version
+}
+
+func OktaProviderBaseURLGetter(comm Common) *string {
+	if comm.Providers == nil || comm.Providers.Okta == nil {
+		return nil
+	}
+	return comm.Providers.Okta.BaseURL
 }
 
 func OktaProviderOrgNameGetter(comm Common) *string {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -152,6 +152,7 @@ type SnowflakeProvider struct {
 //OktaProvider represents Okta configuration
 type OktaProvider struct {
 	OrgName string  `yaml:"org_name,omitempty"`
+	BaseURL *string `yaml:"base_url,omitempty"`
 	Version *string `yaml:"version,omitempty"`
 }
 
@@ -502,6 +503,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		oktaPlan = &OktaProvider{
 			OrgName: *oktaConfig.OrgName,
 			Version: oktaConfig.Version,
+			BaseURL: oktaConfig.BaseURL,
 		}
 	}
 

--- a/templates/common/okta_provider.tmpl
+++ b/templates/common/okta_provider.tmpl
@@ -6,5 +6,8 @@ provider okta {
   version = "~>{{ .Version }}"
   {{ end -}}
   org_name = "{{ .OrgName }}"
+  {{ if .BaseURL -}}
+  base_url = "{{ .BaseURL }}"
+  {{ end -}}
 }
 {{ end }}

--- a/testdata/okta_provider_yaml/fogg.yml
+++ b/testdata/okta_provider_yaml/fogg.yml
@@ -4,7 +4,8 @@
         "providers": {
             "okta": {
                 "version": "aversion",
-                "org_name": "orgname"
+                "org_name": "orgname",
+                "base_url": "oktapreview.com",
             }
         },
         "backend": {

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -5,6 +5,7 @@
 provider okta {
   version  = "~>aversion"
   org_name = "orgname"
+  base_url = "oktapreview.com"
 }
 terraform {
   required_version = "=1.1.1"

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -5,6 +5,7 @@
 provider okta {
   version  = "~>aversion"
   org_name = "orgname"
+  base_url = "oktapreview.com"
 }
 terraform {
   required_version = "~>1.1.1"

--- a/testdata/okta_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/global/fogg.tf
@@ -5,6 +5,7 @@
 provider okta {
   version  = "~>aversion"
   org_name = "orgname"
+  base_url = "oktapreview.com"
 }
 terraform {
   required_version = "~>1.1.1"


### PR DESCRIPTION
### Summary
Allow users to optionally specify [base_url](https://www.terraform.io/docs/providers/okta/index.html#base_url) for okta provider. For example, if you have an oktapreview instance you want to write some test code against. 

### Test Plan
unit tests

### References
https://www.terraform.io/docs/providers/okta/index.html#base_url