### PR TITLE
Add standard tags to accounts components

### DIFF
--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -72,6 +72,17 @@ variable account {
     default = "{{ .AccountName }}"
 }
 
+variable tags {
+  type =  map(string)
+  default = {
+    project   = "{{ .Project }}"
+    env       = "accounts"
+    service   = "{{ .AccountName }}"
+    owner     = "{{ .Owner }}"
+    managedBy = "terraform"
+  }
+}
+
 # map of aws_accounts
 variable aws_accounts {
   type =  map

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -44,6 +44,16 @@ variable account {
   type    = string
   default = "foo"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "foofoo"
+    env       = "accounts"
+    service   = "foo"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map

--- a/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -31,6 +31,16 @@ variable account {
   type    = string
   default = "foo"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "foo"
+    env       = "accounts"
+    service   = "foo"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -33,6 +33,16 @@ variable account {
   type    = string
   default = "foo"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "foofoo"
+    env       = "accounts"
+    service   = "foo"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -32,6 +32,16 @@ variable account {
   type    = string
   default = "foo"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "foo"
+    env       = "accounts"
+    service   = "foo"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -30,6 +30,16 @@ variable account {
   type    = string
   default = "foo"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "foo"
+    env       = "accounts"
+    service   = "foo"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -72,6 +72,16 @@ variable account {
   type    = string
   default = "bar"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "proj"
+    env       = "accounts"
+    service   = "bar"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -44,6 +44,16 @@ variable account {
   type    = string
   default = "foo"
 }
+variable tags {
+  type = map(string)
+  default = {
+    project   = "proj"
+    env       = "accounts"
+    service   = "foo"
+    owner     = "foo@example.com"
+    managedBy = "terraform"
+  }
+}
 # map of aws_accounts
 variable aws_accounts {
   type = map


### PR DESCRIPTION
### Summary
Adds tags variable to accounts components, with standard names for project, env (hardcoded to "accounts") and service (matches the account name). Makes it simpler for adding tags to components such as IAM users that are created in an account component.

### Test Plan
Golden files updated.