### PR TITLE
[feature] templates: type var.tags as an object rather than a map

### DIFF
--- a/templates/account/fogg.tf.tmpl
+++ b/templates/account/fogg.tf.tmpl
@@ -73,7 +73,7 @@ variable account {
 }
 
 variable tags {
-  type =  map(string)
+  type =  object({project: string, env: string, service: string, owner: string, managedBy: string})
   default = {
     project   = "{{ .Project }}"
     env       = "accounts"

--- a/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/component/terraform/fogg.tf.tmpl
@@ -80,7 +80,7 @@ variable owner {
 }
 
 variable tags {
-  type =  map(string)
+  type =  object({project: string, env: string, service: string, owner: string, managedBy: string})
   default = {
     project   = "{{ .Project }}"
     env       = "{{ .Env }}"

--- a/templates/global/fogg.tf.tmpl
+++ b/templates/global/fogg.tf.tmpl
@@ -76,7 +76,7 @@ variable owner {
 }
 
 variable tags {
-  type =  map(string)
+  type =  object({project: string, env: string, service: string, owner: string, managedBy: string})
   default = {
     project   = "{{ .Project }}"
     env       = "{{ .Env }}"

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -45,7 +45,7 @@ variable account {
   default = "foo"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foofoo"
     env       = "accounts"

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foofoo"
     env       = "bar"

--- a/testdata/bless_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/global/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foofoo"
     env       = ""

--- a/testdata/circleci/terraform/global/fogg.tf
+++ b/testdata/circleci/terraform/global/fogg.tf
@@ -32,7 +32,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/github_actions/terraform/global/fogg.tf
+++ b/testdata/github_actions/terraform/global/fogg.tf
@@ -32,7 +32,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -32,7 +32,7 @@ variable account {
   default = "foo"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = "accounts"

--- a/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -37,7 +37,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = "bar"

--- a/testdata/github_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/global/fogg.tf
@@ -37,7 +37,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -34,7 +34,7 @@ variable account {
   default = "foo"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foofoo"
     env       = "accounts"

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -39,7 +39,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foofoo"
     env       = "bar"

--- a/testdata/okta_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/global/fogg.tf
@@ -39,7 +39,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foofoo"
     env       = ""

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -33,7 +33,7 @@ variable account {
   default = "foo"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = "accounts"

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -38,7 +38,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = "bar"

--- a/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
@@ -38,7 +38,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -31,7 +31,7 @@ variable account {
   default = "foo"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = "accounts"

--- a/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -32,7 +32,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = "bar"

--- a/testdata/tfe_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/global/fogg.tf
@@ -36,7 +36,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -73,7 +73,7 @@ variable account {
   default = "bar"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "accounts"

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -45,7 +45,7 @@ variable account {
   default = "foo"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "accounts"

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -53,7 +53,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "prod"

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -53,7 +53,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "prod"

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "prod"

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "staging"

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "staging"

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "staging"

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -50,7 +50,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = ""

--- a/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
@@ -32,7 +32,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "foo"
     env       = ""

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -32,7 +32,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = "staging"

--- a/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
@@ -32,7 +32,7 @@ variable owner {
   default = "foo@example.com"
 }
 variable tags {
-  type = map(string)
+  type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
     project   = "proj"
     env       = ""


### PR DESCRIPTION
### Summary
Change the automatically generated var.tags from a type of `map(string)` to an `object` type. This lets us make stronger assertions in modules that might want to accept these tag objects.

I found this while trying to write a new module:
```
variable tags {
  description = "Standard tags. Typically generated by fogg."
  # type        = object({ env : string, owner : string, project : string, service : string })
  # NOTE: fogg.tf types this as a map(string) rather than an object. Have to fix there first.
  type = map(string)
}
```

### Test Plan
Unit tests

### References