### PR TITLE
[feature] configure bless providers with a role

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -132,6 +132,7 @@ type BlessProvider struct {
 	AdditionalRegions []string `yaml:"additional_regions,omitempty"`
 	AWSProfile        *string  `yaml:"aws_profile,omitempty"`
 	AWSRegion         *string  `yaml:"aws_region,omitempty"`
+	RoleArn           *string  `yaml:"role_arn,omitempty"`
 	Version           *string  `yaml:"version,omitempty"`
 }
 

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -253,16 +253,18 @@ func ResolveOktaProvider(commons ...Common) *OktaProvider {
 
 func ResolveBlessProvider(commons ...Common) *BlessProvider {
 	profile := lastNonNil(BlessProviderProfileGetter, commons...)
+	roleArn := lastNonNil(BlessProviderRoleArnGetter, commons...)
 	region := lastNonNil(BlessProviderRegionGetter, commons...)
 
 	// required fields
-	if profile == nil || region == nil {
+	if (profile == nil && roleArn == nil) || region == nil {
 		return nil
 	}
 
 	return &BlessProvider{
 		AWSProfile: profile,
 		AWSRegion:  region,
+		RoleArn:    roleArn,
 
 		Version:           lastNonNil(BlessProviderVersionGetter, commons...),
 		AdditionalRegions: ResolveOptionalStringSlice(BlessProviderAdditionalRegionsGetter, commons...),
@@ -596,6 +598,14 @@ func BlessProviderProfileGetter(comm Common) *string {
 	}
 	return comm.Providers.Bless.AWSProfile
 }
+
+func BlessProviderRoleArnGetter(comm Common) *string {
+	if comm.Providers == nil || comm.Providers.Bless == nil {
+		return nil
+	}
+	return comm.Providers.Bless.RoleArn
+}
+
 func BlessProviderRegionGetter(comm Common) *string {
 	if comm.Providers == nil || comm.Providers.Bless == nil {
 		return nil

--- a/config/v2/validation.go
+++ b/config/v2/validation.go
@@ -174,8 +174,9 @@ func (p *BlessProvider) Validate(component string) error {
 	if p == nil {
 		return nil // nothing to do
 	}
-	if p.AWSProfile == nil {
-		errs = multierror.Append(errs, fmt.Errorf("bless provider aws_profile required in %s", component))
+
+	if p.AWSProfile == nil && p.RoleArn == nil {
+		errs = multierror.Append(errs, fmt.Errorf("bless provider requires aws_profile or role_arn in %s", component))
 	}
 	if p.AWSRegion == nil {
 		errs = multierror.Append(errs, fmt.Errorf("bless provider aws_region required in %s", component))

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -159,8 +159,9 @@ type OktaProvider struct {
 //BlessProvider represents Bless ssh provider configuration
 type BlessProvider struct {
 	AdditionalRegions []string `yaml:"additional_regions,omitempty"`
-	AWSProfile        string   `yaml:"aws_profile,omitempty"`
+	AWSProfile        *string  `yaml:"aws_profile,omitempty"`
 	AWSRegion         string   `yaml:"aws_region,omitempty"`
+	RoleArn           *string  `yaml:"role_arn,omitempty"`
 	Version           *string  `yaml:"version,omitempty"`
 }
 
@@ -509,11 +510,12 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 
 	var blessPlan *BlessProvider
 	blessConfig := v2.ResolveBlessProvider(commons...)
-	if blessConfig != nil && blessConfig.AWSProfile != nil && blessConfig.AWSRegion != nil {
+	if blessConfig != nil && (blessConfig.AWSProfile != nil || blessConfig.RoleArn != nil) && blessConfig.AWSRegion != nil {
 		blessPlan = &BlessProvider{
-			AWSProfile:        *blessConfig.AWSProfile,
+			AWSProfile:        blessConfig.AWSProfile,
 			AWSRegion:         *blessConfig.AWSRegion,
 			AdditionalRegions: blessConfig.AdditionalRegions,
+			RoleArn:           blessConfig.RoleArn,
 			Version:           blessConfig.Version,
 		}
 	}

--- a/templates/common/bless_provider.tmpl
+++ b/templates/common/bless_provider.tmpl
@@ -5,7 +5,12 @@ provider bless {
   version = "~>{{ .Version }}"
   {{ end -}}
   region  = "{{ .AWSRegion }}"
+  {{ if .AWSProfile -}}
   profile = "{{ .AWSProfile }}"
+  {{ end -}}
+  {{ if .RoleArn -}}
+  role_arn = "{{ .RoleArn }}"
+  {{ end -}}
 }
 
 {{ $outer := . -}}
@@ -15,8 +20,13 @@ provider bless {
   {{ if $outer.Version -}}
   version = "~>{{ $outer.Version }}"
   {{ end -}}
-  region = "{{ $region }}"
+  region  = "{{ $region }}"
+  {{ if $outer.AWSProfile}}
   profile = "{{ $outer.AWSProfile }}"
+  {{ end -}}
+  {{ if $outer.RoleArn}}
+  role_arn = "{{ $outer.RoleArn }}"
+  {{ end -}}
 }
 {{ end }}
 {{ end }}

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -10,12 +10,14 @@ provider bless {
   alias   = "a"
   version = "~>0.0.0"
   region  = "a"
+
   profile = "foofoofoo"
 }
 provider bless {
   alias   = "b"
   version = "~>0.0.0"
   region  = "b"
+
   profile = "foofoofoo"
 }
 terraform {

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -10,12 +10,14 @@ provider bless {
   alias   = "a"
   version = "~>0.0.0"
   region  = "a"
+
   profile = "foofoofoo"
 }
 provider bless {
   alias   = "b"
   version = "~>0.0.0"
   region  = "b"
+
   profile = "foofoofoo"
 }
 terraform {

--- a/testdata/bless_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/global/fogg.tf
@@ -10,12 +10,14 @@ provider bless {
   alias   = "a"
   version = "~>0.0.0"
   region  = "a"
+
   profile = "foofoofoo"
 }
 provider bless {
   alias   = "b"
   version = "~>0.0.0"
   region  = "b"
+
   profile = "foofoofoo"
 }
 terraform {

--- a/testdata/v2_full_yaml/fogg.yml
+++ b/testdata/v2_full_yaml/fogg.yml
@@ -7,11 +7,19 @@ accounts:
           - us-east-1
           - us-east-2
         role: foo
+      bless:
+        role_arn: arn:aws:iam::1234567890:role/roll
+        version: 0.4.2
+        aws_region: us-west-2
   foo:
     providers:
       aws:
         account_id: 123
         role: roll
+      bless:
+        aws_profile: prof
+        version: 0.4.2
+        aws_region: us-west-2
 defaults:
   backend:
     bucket: buck

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -42,6 +42,12 @@ provider aws {
   allowed_account_ids = [456]
 }
 
+
+provider bless {
+  version  = "~>0.4.2"
+  region   = "us-west-2"
+  role_arn = "arn:aws:iam::1234567890:role/roll"
+}
 terraform {
   required_version = "=0.100.0"
   backend s3 {

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -14,6 +14,12 @@ provider aws {
 }
 # Aliased Providers (for doing things in every region).
 
+
+provider bless {
+  version = "~>0.4.2"
+  region  = "us-west-2"
+  profile = "prof"
+}
 terraform {
   required_version = "=0.100.0"
   backend s3 {


### PR DESCRIPTION
Allow configuring bless providers with a role_arn, in addition to a profile.

Support was
[previously](https://github.com/chanzuckerberg/terraform-provider-bless/pull/33)
added to the provider.

### Test Plan
* unit tests

### References
* https://github.com/chanzuckerberg/terraform-provider-bless/pull/33