### PR TITLE
[fix] typo in experimental auto-remote-state code

### DIFF
--- a/exp/state/remote_state.go
+++ b/exp/state/remote_state.go
@@ -76,7 +76,7 @@ func Run(fs afero.Fs, configFile, path string) error {
 			conf.Accounts[component.Name] = c
 		}
 
-	case "env":
+	case "envs":
 		if len(accounts) > 0 || len(components) > 0 {
 			c := conf.Envs[component.Env].Components[component.Name]
 


### PR DESCRIPTION
Experimental code, so not well tested. Turns out there was a typo.

### Test Plan
* manually tested in one repo

### References