### PR TITLE
[refactor] flatten cmd/exp package into cmd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,7 @@
 run:
-  skip-dirs:
-    - exp/examine
   skip-files:
-    - cmd/exp/entropy.go
+    - cmd/exp_examine.go
+    - cmd/exp_entropy.go
     - exp/examine/local.go
     - exp/examine/util.go
   linters:

--- a/cmd/exp.go
+++ b/cmd/exp.go
@@ -1,9 +1,13 @@
-package exp
+package cmd
 
 import "github.com/spf13/cobra"
 
+func init() {
+	rootCmd.AddCommand(expCmd)
+}
+
 // ExpCmd is a subcommand for experimental commands
-var ExpCmd = &cobra.Command{
+var expCmd = &cobra.Command{
 	Use:          "exp",
 	Short:        "Experimental commands",
 	Long:         "Grouping of experimental commands. These are experimental and prone to change",

--- a/cmd/exp_auto_remote_state.go
+++ b/cmd/exp_auto_remote_state.go
@@ -1,4 +1,4 @@
-package exp
+package cmd
 
 import (
 	"os"
@@ -13,7 +13,7 @@ func init() {
 	autoRemoteStateCmd.Flags().String("path", "", "path to a working directory")
 	autoRemoteStateCmd.Flags().StringP("config", "c", "fogg.yml", "Use this to override the fogg config file.")
 
-	ExpCmd.AddCommand(autoRemoteStateCmd)
+	expCmd.AddCommand(autoRemoteStateCmd)
 }
 
 var autoRemoteStateCmd = &cobra.Command{

--- a/cmd/exp_aws_config.go
+++ b/cmd/exp_aws_config.go
@@ -1,4 +1,4 @@
-package exp
+package cmd
 
 import (
 	"fmt"
@@ -23,7 +23,7 @@ func init() {
 	awsConfigCmd.Flags().String("fogg-config", "fogg.yml", "Use this to override the fogg config file.")
 	awsConfigCmd.Flags().String("aws-config", "~/.aws/config", "Path to your AWS config")
 
-	ExpCmd.AddCommand(awsConfigCmd)
+	expCmd.AddCommand(awsConfigCmd)
 }
 
 var awsConfigCmd = &cobra.Command{

--- a/cmd/exp_entropy.go
+++ b/cmd/exp_entropy.go
@@ -1,4 +1,4 @@
-package exp
+package cmd
 
 import (
 	"fmt"
@@ -14,20 +14,12 @@ func init() {
 	entropyCmd.Flags().StringP("plan-file", "f", "TODO", "Path to Terraform Plan file to parse.")
 	entropyCmd.Flags().StringP("output-file", "o", "TODO", "Path to write instrumentation to")
 
-	ExpCmd.AddCommand(entropyCmd)
+	expCmd.AddCommand(entropyCmd)
 }
 
 const (
 	allActions = "AllActions"
 )
-
-type terraformDiff struct {
-	Address      string `logfmt:"address,omitempty"`
-	ResourceMode string `logfmt:"resource_mode,omitempty"`
-	Action       string `logfmt:"action,omitempty"`
-	Project      string `logfmt:"project,omitempty"`
-	Component    string `logfmt:"component,omitempty"`
-}
 
 var entropyCmd = &cobra.Command{
 	Use:   "entropy",

--- a/cmd/exp_examine.go
+++ b/cmd/exp_examine.go
@@ -1,17 +1,16 @@
-package exp
+package cmd
 
 import (
 	"os"
 
 	"github.com/chanzuckerberg/fogg/errs"
 	"github.com/chanzuckerberg/fogg/exp/examine"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	ExpCmd.AddCommand(examineCmd)
+	expCmd.AddCommand(examineCmd)
 }
 
 //TODO:(EC) Create a flag for path to walk
@@ -32,13 +31,4 @@ var examineCmd = &cobra.Command{
 
 		return examine.Examine(fs, pwd)
 	},
-}
-
-func openGitOrExit(fs afero.Fs) {
-	_, err := fs.Stat(".git")
-	if err != nil {
-		// assuming this means no repository
-		logrus.Fatal("fogg must be run from the root of a git repo")
-		os.Exit(1)
-	}
 }

--- a/cmd/exp_migrate.go
+++ b/cmd/exp_migrate.go
@@ -1,4 +1,4 @@
-package exp
+package cmd
 
 import (
 	"github.com/chanzuckerberg/fogg/exp/migrate"
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	ExpCmd.AddCommand(migrateCmd)
+	expCmd.AddCommand(migrateCmd)
 }
 
 var migrateCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"runtime/pprof"
 
-	"github.com/chanzuckerberg/fogg/cmd/exp"
 	"github.com/chanzuckerberg/fogg/errs"
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
@@ -20,7 +19,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "enable verbose output")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "do not output to console; use return code to determine success/failure")
 	rootCmd.PersistentFlags().StringVarP(&cpuprofile, "cpuprofile", "p", "", "activate cpu profiling via pprof and write to file")
-	rootCmd.AddCommand(exp.ExpCmd)
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Flatten cmd/exp into cmd, prefixing each file with exp_. This should
make it easier to DRY up some code in these two packages.


### Test Plan
* ci