### PR TITLE
[fix] exp auto-remote-state to handle empty lists correctly

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -235,8 +235,8 @@ type CommonCI struct {
 }
 
 type DependsOn struct {
-	Accounts   []string `yaml:"accounts,omitempty"`
-	Components []string `yaml:"components,omitempty"`
+	Accounts   []string `yaml:"accounts"`
+	Components []string `yaml:"components"`
 }
 
 type CIProviderConfig struct {

--- a/exp/state/remote_state.go
+++ b/exp/state/remote_state.go
@@ -66,30 +66,24 @@ func Run(fs afero.Fs, configFile, path string) error {
 
 	switch component.Kind {
 	case "accounts":
-		if len(accounts) > 0 {
-			c := conf.Accounts[component.Name]
-			if c.Common.DependsOn == nil {
-				c.Common.DependsOn = &v2.DependsOn{}
-			}
-
-			c.DependsOn.Accounts = accounts
-			conf.Accounts[component.Name] = c
+		c := conf.Accounts[component.Name]
+		if c.Common.DependsOn == nil {
+			c.Common.DependsOn = &v2.DependsOn{}
 		}
 
+		c.DependsOn.Accounts = accounts
+		conf.Accounts[component.Name] = c
 	case "envs":
-		if len(accounts) > 0 || len(components) > 0 {
-			c := conf.Envs[component.Env].Components[component.Name]
+		c := conf.Envs[component.Env].Components[component.Name]
 
-			if c.Common.DependsOn == nil {
-				c.Common.DependsOn = &v2.DependsOn{}
-			}
-
-			c.DependsOn.Accounts = accounts
-			c.DependsOn.Components = components
-
-			conf.Envs[component.Env].Components[component.Name] = c
+		if c.Common.DependsOn == nil {
+			c.Common.DependsOn = &v2.DependsOn{}
 		}
 
+		c.DependsOn.Accounts = accounts
+		c.DependsOn.Components = components
+
+		conf.Envs[component.Env].Components[component.Name] = c
 	default:
 		return fmt.Errorf("unknown component.Kind: %s", component.Kind)
 	}


### PR DESCRIPTION
Do not ignore empty lists in the `exp auto-remote-state` command.
Without this change an empty list would not get written to fogg.yml,
meaning that components with zero remote state dependencies would not
get updated.

### Test Plan
* ci
* tested manually on 1 internal repo

### References