### PR TITLE
[feature] fogg fmt - standard formatting for fogg.yml

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/chanzuckerberg/fogg/config"
+	"github.com/chanzuckerberg/fogg/errs"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// planCmd.Flags().StringP("config", "c", "fogg.yml", "Use this to override the fogg config file.")
+	rootCmd.AddCommand(fmtCmd)
+}
+
+var fmtCmd = &cobra.Command{
+	Use:           "fmt",
+	Short:         "format",
+	Long:          "",
+	SilenceErrors: true, // If we don't silence here, cobra will print them. But we want to do that in cmd/root.go
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		fs, err := pwdFs()
+		if err != nil {
+			return err
+		}
+
+		// if fogg.yml exists, read and format it
+		if fileExists("fogg.yml") {
+			c, err := config.FindAndReadConfig(fs, "fogg.yml")
+			if err != nil {
+				return err
+			}
+			err = c.Write(fs, "fogg.yml")
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func pwdFs() (afero.Fs, error) {
+	// Set up fs
+	pwd, e := os.Getwd()
+	if e != nil {
+		return nil, errs.WrapUser(e, "can't get pwd")
+	}
+	fs := afero.NewBasePathFs(afero.NewOsFs(), pwd)
+	return fs, nil
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/chanzuckerberg/fogg/errs"
 	"github.com/chanzuckerberg/fogg/plan"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -23,12 +20,10 @@ var planCmd = &cobra.Command{
 
 		var e error
 		// Set up fs
-		pwd, e := os.Getwd()
+		fs, e := pwdFs()
 		if e != nil {
-			return errs.WrapUser(e, "can't get pwd")
+			return e
 		}
-		fs := afero.NewBasePathFs(afero.NewOsFs(), pwd)
-
 		// handle flags
 		configFile, e := cmd.Flags().GetString("config")
 		if e != nil {

--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -56,14 +56,14 @@ func (c *Config) Write(fs afero.Fs, path string) error {
 }
 
 type Config struct {
-	Accounts map[string]Account `yaml:"accounts,omitempty"`
+	Version  int                `validate:"required,eq=2"`
 	Defaults Defaults           `yaml:"defaults" validate:"required"`
-	Docker   bool               `yaml:"docker,omitempty"`
-	Envs     map[string]Env     `yaml:"envs,omitempty"`
 	Global   Component          `yaml:"global,omitempty"`
+	Accounts map[string]Account `yaml:"accounts,omitempty"`
+	Envs     map[string]Env     `yaml:"envs,omitempty"`
 	Modules  map[string]Module  `yaml:"modules,omitempty"`
 	Plugins  Plugins            `yaml:"plugins,omitempty"`
-	Version  int                `validate:"required,eq=2"`
+	Docker   bool               `yaml:"docker,omitempty"`
 }
 
 type Common struct {

--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -56,14 +56,14 @@ func (c *Config) Write(fs afero.Fs, path string) error {
 }
 
 type Config struct {
-	Version  int                `validate:"required,eq=2"`
-	Defaults Defaults           `yaml:"defaults" validate:"required"`
-	Global   Component          `yaml:"global,omitempty"`
 	Accounts map[string]Account `yaml:"accounts,omitempty"`
+	Defaults Defaults           `yaml:"defaults" validate:"required"`
+	Docker   bool               `yaml:"docker,omitempty"`
 	Envs     map[string]Env     `yaml:"envs,omitempty"`
+	Global   Component          `yaml:"global,omitempty"`
 	Modules  map[string]Module  `yaml:"modules,omitempty"`
 	Plugins  Plugins            `yaml:"plugins,omitempty"`
-	Docker   bool               `yaml:"docker,omitempty"`
+	Version  int                `validate:"required,eq=2"`
 }
 
 type Common struct {

--- a/templates/repo/Makefile.tmpl
+++ b/templates/repo/Makefile.tmpl
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/bless_provider_yaml/Makefile
+++ b/testdata/bless_provider_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/circleci/Makefile
+++ b/testdata/circleci/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/github_actions/Makefile
+++ b/testdata/github_actions/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/github_provider_yaml/Makefile
+++ b/testdata/github_provider_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/okta_provider_yaml/Makefile
+++ b/testdata/okta_provider_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/snowflake_provider_yaml/Makefile
+++ b/testdata/snowflake_provider_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/tfe_provider_yaml/Makefile
+++ b/testdata/tfe_provider_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/v2_full_yaml/Makefile
+++ b/testdata/v2_full_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/v2_minimal_valid_yaml/Makefile
+++ b/testdata/v2_minimal_valid_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \

--- a/testdata/v2_no_aws_provider_yaml/Makefile
+++ b/testdata/v2_no_aws_provider_yaml/Makefile
@@ -39,8 +39,12 @@ lint-modules: ## lint the terraform code in terraform/modules
 	done
 .PHONY: lint-modules
 
-fmt: fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
+fmt: fmt-fogg fmt-accounts fmt-envs fmt-global fmt-modules ## format code in this repo
 .PHONY: fmt
+
+fmt-fogg:
+	.fogg/bin/fogg fmt
+.PHONY: fmt-fogg
 
 fmt-accounts: ## format code in terraform/accounts
 	@for account in $(ACCOUNTS); do \


### PR DESCRIPTION
Add `fogg fmt` command which implements a standard formatting for the fogg.yml file (shared with other commands which update fogg.yml.

Various scripts, code editors and tools format yaml files differently, leading to diffs with a lot of noise. This command will help enforce a standardized format.

### Test Plan
* manually tested on all internal repos

### References
*