### PR TITLE
[fix] check-auth on remote backend

### DIFF
--- a/templates/common/make_vars.tmpl
+++ b/templates/common/make_vars.tmpl
@@ -3,11 +3,14 @@ export TERRAFORM_VERSION := {{ .TerraformVersion }}
 export TFLINT_ENABLED := {{ if .TfLint.Enabled }}1{{ else }}0{{ end }}
 export TF_PLUGIN_CACHE_DIR := {{ .PathToRepoRoot }}/.terraform.d/plugin-cache
 export TF_BACKEND_KIND := {{ .Backend.Kind }}
-{{ if .Backend.S3 }}{{ if .Backend.S3.Profile}}export AWS_BACKEND_PROFILE := {{ .Backend.S3.Profile }}{{ end }}{{end}}
-{{ if .Backend.S3 }}{{ if .Backend.S3.RoleArn }}export AWS_BACKEND_ROLE_ARN := {{ .Backend.S3.RoleArn }}{{ end }}{{end}}
-{{ if .ProviderConfiguration.AWS }}{{ if .ProviderConfiguration.AWS.Profile }}export AWS_PROVIDER_PROFILE := {{ .ProviderConfiguration.AWS.Profile }}{{ end }}{{ end }}
-{{ if .ProviderConfiguration.AWS }}{{ if .ProviderConfiguration.AWS.RoleArn }}export AWS_PROVIDER_ROLE_ARN := {{ .ProviderConfiguration.AWS.RoleArn }}{{ end }}{{ end }}
+{{ if .Backend.S3 }}
+{{ if .Backend.S3.Profile}}export AWS_BACKEND_PROFILE := {{ .Backend.S3.Profile }}{{ end }}
+{{ if .Backend.S3.RoleArn }}export AWS_BACKEND_ROLE_ARN := {{ .Backend.S3.RoleArn }}{{ end }}
+{{ if .ProviderConfiguration.AWS }}
+{{ if .ProviderConfiguration.AWS.Profile }}export AWS_PROVIDER_PROFILE := {{ .ProviderConfiguration.AWS.Profile }}{{ end }}
+{{ if .ProviderConfiguration.AWS.RoleArn }}export AWS_PROVIDER_ROLE_ARN := {{ .ProviderConfiguration.AWS.RoleArn }}{{ end }}
 {{if .ProviderConfiguration.Heroku}}export HEROKU_PROVIDER := 1{{end}}
-
+{{ end }}
+{{ end }}
 include {{ .PathToRepoRoot }}/scripts/component.mk
 {{ end }}

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/Makefile
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foofoo
-
-
 
 
 

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/Makefile
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foofoo
-
-
 
 
 

--- a/testdata/bless_provider_yaml/terraform/global/Makefile
+++ b/testdata/bless_provider_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foofoo
-
-
 
 
 

--- a/testdata/circleci/terraform/global/Makefile
+++ b/testdata/circleci/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/github_actions/terraform/global/Makefile
+++ b/testdata/github_actions/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/github_provider_yaml/terraform/accounts/foo/Makefile
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/github_provider_yaml/terraform/envs/bar/bam/Makefile
+++ b/testdata/github_provider_yaml/terraform/envs/bar/bam/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/github_provider_yaml/terraform/global/Makefile
+++ b/testdata/github_provider_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/Makefile
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foofoo
-
-
 
 
 

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/Makefile
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foofoo
-
-
 
 
 

--- a/testdata/okta_provider_yaml/terraform/global/Makefile
+++ b/testdata/okta_provider_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foofoo
-
-
 
 
 

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/Makefile
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/Makefile
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/snowflake_provider_yaml/terraform/global/Makefile
+++ b/testdata/snowflake_provider_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/Makefile
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/tfe_provider_yaml/terraform/envs/bar/bam/Makefile
+++ b/testdata/tfe_provider_yaml/terraform/envs/bar/bam/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/tfe_provider_yaml/terraform/global/Makefile
+++ b/testdata/tfe_provider_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/v2_full_yaml/fogg.yml
+++ b/testdata/v2_full_yaml/fogg.yml
@@ -80,6 +80,10 @@ envs:
         module_source: github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.30.0
         module_name: prod-vpc
   staging:
+    backend:
+      kind: remote
+      host_name: example.com
+      organization: foo
     components:
       comp_helm_template:
         eks:

--- a/testdata/v2_full_yaml/terraform/accounts/bar/Makefile
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/Makefile
@@ -6,10 +6,13 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
 
+
 export AWS_PROVIDER_ROLE_ARN := arn:aws:iam::456:role/foo
+
 
 
 include ../../..//scripts/component.mk

--- a/testdata/v2_full_yaml/terraform/accounts/foo/Makefile
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/Makefile
@@ -6,10 +6,13 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
 
+
 export AWS_PROVIDER_ROLE_ARN := arn:aws:iam::123:role/roll
+
 
 
 include ../../..//scripts/component.mk

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/Makefile
@@ -6,9 +6,12 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
+
 export AWS_PROVIDER_PROFILE := profile
+
 
 
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/Makefile
@@ -6,11 +6,14 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
+
 
 export AWS_PROVIDER_PROFILE := profile
 
 export HEROKU_PROVIDER := 1
+
 
 include ../../../..//scripts/component.mk
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/okta/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/prod/okta/Makefile
@@ -6,9 +6,12 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
+
 export AWS_PROVIDER_PROFILE := profile
+
 
 
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/sentry/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/prod/sentry/Makefile
@@ -6,9 +6,12 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
+
 export AWS_PROVIDER_PROFILE := profile
+
 
 
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/Makefile
@@ -6,9 +6,12 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
+
 export AWS_PROVIDER_PROFILE := profile
+
 
 
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/Makefile
@@ -5,12 +5,7 @@
 export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
-export TF_BACKEND_KIND := s3
-export AWS_BACKEND_PROFILE := comp1
-
-export AWS_PROVIDER_PROFILE := profile
-
-
+export TF_BACKEND_KIND := remote
 
 include ../../../..//scripts/component.mk
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -12,15 +12,13 @@ provider aws {
 terraform {
   required_version = "=0.100.0"
 
-  backend s3 {
+  backend remote {
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/comp1.tfstate"
-    encrypt = true
-    region  = "us-west-2"
-    profile = "comp1"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces {
+      name = "staging-comp1"
+    }
 
   }
   required_providers {
@@ -129,30 +127,28 @@ data terraform_remote_state global {
   }
 }
 data terraform_remote_state comp2 {
-  backend = "s3"
+  backend = "remote"
   config = {
 
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/comp2.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces = {
+      name = "staging-comp2"
+    }
 
   }
 }
 data terraform_remote_state vpc {
-  backend = "s3"
+  backend = "remote"
   config = {
 
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/vpc.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces = {
+      name = "staging-vpc"
+    }
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/Makefile
@@ -5,12 +5,7 @@
 export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
-export TF_BACKEND_KIND := s3
-export AWS_BACKEND_PROFILE := profile
-
-export AWS_PROVIDER_PROFILE := profile
-
-
+export TF_BACKEND_KIND := remote
 
 include ../../../..//scripts/component.mk
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -12,15 +12,13 @@ provider aws {
 terraform {
   required_version = "=0.100.0"
 
-  backend s3 {
+  backend remote {
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/comp2.tfstate"
-    encrypt = true
-    region  = "us-west-2"
-    profile = "profile"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces {
+      name = "staging-comp2"
+    }
 
   }
   required_providers {
@@ -129,30 +127,28 @@ data terraform_remote_state global {
   }
 }
 data terraform_remote_state comp1 {
-  backend = "s3"
+  backend = "remote"
   config = {
 
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/comp1.tfstate"
-    region  = "us-west-2"
-    profile = "comp1"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces = {
+      name = "staging-comp1"
+    }
 
   }
 }
 data terraform_remote_state vpc {
-  backend = "s3"
+  backend = "remote"
   config = {
 
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/vpc.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces = {
+      name = "staging-vpc"
+    }
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/Makefile
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/Makefile
@@ -5,12 +5,7 @@
 export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
-export TF_BACKEND_KIND := s3
-export AWS_BACKEND_PROFILE := profile
-
-export AWS_PROVIDER_PROFILE := profile
-
-
+export TF_BACKEND_KIND := remote
 
 include ../../../..//scripts/component.mk
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -12,15 +12,13 @@ provider aws {
 terraform {
   required_version = "=0.100.0"
 
-  backend s3 {
+  backend remote {
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/vpc.tfstate"
-    encrypt = true
-    region  = "us-west-2"
-    profile = "profile"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces {
+      name = "staging-vpc"
+    }
 
   }
   required_providers {
@@ -129,30 +127,28 @@ data terraform_remote_state global {
   }
 }
 data terraform_remote_state comp1 {
-  backend = "s3"
+  backend = "remote"
   config = {
 
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/comp1.tfstate"
-    region  = "us-west-2"
-    profile = "comp1"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces = {
+      name = "staging-comp1"
+    }
 
   }
 }
 data terraform_remote_state comp2 {
-  backend = "s3"
+  backend = "remote"
   config = {
 
 
-    bucket = "buck"
-
-    key     = "terraform/proj/envs/staging/components/comp2.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
-
+    hostname     = "example.com"
+    organization = "foo"
+    workspaces = {
+      name = "staging-comp2"
+    }
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/global/Makefile
+++ b/testdata/v2_full_yaml/terraform/global/Makefile
@@ -6,9 +6,12 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
 
+
 export AWS_PROVIDER_PROFILE := profile
+
 
 
 

--- a/testdata/v2_minimal_valid_yaml/terraform/global/Makefile
+++ b/testdata/v2_minimal_valid_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 1.1.1
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := foo
-
-
 
 
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/Makefile
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
-
-
 
 
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/global/Makefile
+++ b/testdata/v2_no_aws_provider_yaml/terraform/global/Makefile
@@ -6,9 +6,8 @@ export TERRAFORM_VERSION := 0.100.0
 export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
+
 export AWS_BACKEND_PROFILE := profile
-
-
 
 
 


### PR DESCRIPTION
When we are using a remote backend the local auth checks no longer make
sense, disable them by not setting the env variables for checking.