### PR TITLE
fix:goreleaser: brews.github deprecated in favor of brews.tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ release:
 
 brews:
   - description: 'Terraform without pain.'
-    github:
+    tap:
       owner: chanzuckerberg
       name: homebrew-tap
     homepage: 'https://github.com/chanzuckerberg/fogg'


### PR DESCRIPTION
### Summary
https://goreleaser.com/deprecations/#brewsgithub