### PR TITLE
[bugfix] Add required keys for datadog provider

### DIFF
--- a/templates/common/datadog_provider.tmpl
+++ b/templates/common/datadog_provider.tmpl
@@ -1,4 +1,6 @@
 {{define "datadog_provider"}}
 provider datadog {
+  api_key = "{{ .dd_api_key }}"
+  app_key = "{{ .dd_app_key }}"
 }
 {{ end }}


### PR DESCRIPTION
### Summary

I'm trying to use datadog in my workspace but the fogg provided datadog provider is [missing](https://si.prod.tfe.czi.technology/app/lp-infra/workspaces/ci-infra-tasks/runs/run-ipmYWwaWhJ4fqxHQ) `api_key` and `app_key`.

Our earlier projects specified `provider datadog` [explicitly](https://github.com/FB-PLP/terraform-infra-management/commit/7a4571b09517e891d93644da7c567c1d2f69fb72#diff-83bff0c3be89b56871480383739c76ab56d5fde14891ed954c6972fb96231fd0). But it seems like all provider declaration is now [moved to fogg](https://github.com/FB-PLP/terraform-infra-management/commit/fcee67d1f07f4d792eaf2f001ca461e84f7fc704).

When provider declaration moved to fogg it could've broke our other apps but maybe it didn't because they're already built?

### Test Plan
I'm new here. I'm not even sure what this code-change does, but it _seems_ like the sorta thing that would need to happen to unbreak the dd provider
