### PR TITLE
Bug validate circle_ci parameters.

### DIFF
--- a/config/v2/validation_test.go
+++ b/config/v2/validation_test.go
@@ -324,6 +324,35 @@ func TestConfig_ValidateTravis(t *testing.T) {
 	}
 }
 
+func TestConfig_ValidateCircleCI(t *testing.T) {
+	tests := []struct {
+		fileName string
+		wantErr  bool
+	}{
+		{"v2_invalid_circle_ci_command_yaml", true},
+	}
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.fileName, func(t *testing.T) {
+			r := require.New(t)
+			fs, _, e := util.TestFs()
+			r.NoError(e)
+
+			b, e := util.TestFile(tt.fileName)
+			r.NoError(e)
+			e = afero.WriteFile(fs, "fogg.yml", b, 0644)
+			r.NoError(e)
+
+			c, e := ReadConfig(fs, b, "fogg.yml")
+			r.NoError(e)
+
+			if err := c.ValidateCircleCI(); (err != nil) != tt.wantErr {
+				t.Errorf("Config.ValidateCircleCI() error = %v, wantErr %v (err != nil) %v", err, tt.wantErr, (err != nil))
+			}
+		})
+	}
+}
+
 func TestFailOnTF11(t *testing.T) {
 	r := require.New(t)
 

--- a/testdata/v2_invalid_circle_ci_command_yaml/fogg.yml
+++ b/testdata/v2_invalid_circle_ci_command_yaml/fogg.yml
@@ -1,0 +1,37 @@
+{
+    "version": 2,
+    "defaults": {
+        "providers": {},
+        "backend": {
+            "bucket": "bucket",
+            "region": "region",
+            "profile": "foo"
+        },
+        "project": "foo",
+        "owner": "foo@example.com",
+        "terraform_version": "1.1.1",
+        "tools": {
+            "circle_ci": {
+                "enabled": true,
+                "aws_iam_role_name": "test-role",
+                "command": "lint"
+            }
+        }
+    },
+    "accounts": {
+        "okta-czi-duo": {
+            "providers": {
+                "okta": {
+                    "org_name": "testo",
+                    "version": "v3.0.1"
+                }
+            },
+            "tools": {
+                "circle_ci": {
+                     "aws_iam_role_name": "test-role",
+                    "command": "cake"
+                }
+            }
+        }
+    }
+}

--- a/testdata/v2_invalid_circle_ci_command_yaml/fogg.yml
+++ b/testdata/v2_invalid_circle_ci_command_yaml/fogg.yml
@@ -13,7 +13,6 @@
         "tools": {
             "circle_ci": {
                 "enabled": true,
-                "aws_iam_role_name": "test-role",
                 "command": "lint"
             }
         }
@@ -28,7 +27,6 @@
             },
             "tools": {
                 "circle_ci": {
-                     "aws_iam_role_name": "test-role",
                     "command": "cake"
                 }
             }


### PR DESCRIPTION
### Summary
Validate CircleCI settings in fog.yml file.

### Test Plan
Its easy to test - create a circle_ci section with enabled=true but one of the command or aws_iam_role_name missing. In the current version you will get pointer exceptions, with the new check you will get an appropriate error.

### References

