### PR TITLE
provide Github token to the apply step during CI

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -35,7 +35,10 @@ jobs:
           {{ end }}
       {{ end }}
       - run: FOGG_VERSION="v{{ $githubActionsCI.FoggVersion }}" make setup
-      - run: |
+      - name: fogg apply
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
           .fogg/bin/fogg apply
           if [ "$(git status --porcelain)" != "" ]; then
             echo "git tree is dirty after running fogg apply"


### PR DESCRIPTION
### Summary
When we use Fogg CI in a private repo, we are unable to use pinned URL references to the repo itself as values of `module_source`, because Fogg (via go-getter) is not authorized to download them. The minimal fix for this is to populate a GITHUB_TOKEN env var during the `fogg apply` step of Github CI.

### Test Plan
unittests
