### PR TITLE
feat[terraform-docs]: installing terraform-docs

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -26,7 +26,7 @@ jobs:
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user

--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -21,6 +21,12 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.6'
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -11,7 +11,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -35,7 +41,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -56,7 +68,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -77,7 +95,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -98,7 +122,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -119,7 +149,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -140,7 +176,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: "3.6"
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
@@ -41,13 +41,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -68,13 +68,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -95,13 +95,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -122,13 +122,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -149,13 +149,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user
@@ -176,13 +176,13 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - run: |
           # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -14,6 +14,12 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.6'
+      - run: |
+          # https://terraform-docs.io/user-guide/installation/#pre-compiled-binary
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          echo "$PWD/terraform-docs" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -19,7 +19,7 @@ jobs:
           curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
-          echo "$PWD/terraform-docs" >> $GITHUB_PATH
+          echo "$PWD" >> $GITHUB_PATH
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user


### PR DESCRIPTION
### Summary
I noticed that a lot of the PRs for fogg related repos were throwing this error: 

~~~
Run cd terraform/modules/aws-iam-eks-pod-role
Terraform v0.13.5 is already installed
fmt: 
/home/runner/work/shared-infra/shared-infra/scripts/update-readme.sh: line 12: terraform-docs: command not found
Docs are out of date, run `make docs`
~~~

[Here](https://github.com/chanzuckerberg/shared-infra/runs/3146638646?check_suite_focus=true#step:195:1) is an example.

This PR should fix this by installing `terraform-docs` in the Github Action template and add the binary to the `$GITHUB_PATH` variable.

### Test Plan

* Pull new version of fogg
* Create a fogg repo or use an existing fogg repo
* Make README that needs formatting
* Push a PR for that README
* Verify the error is no longer there.
