### PR TITLE
fix[trace]: making a skipped touch a trace log

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -322,7 +322,7 @@ func touchFile(dest afero.Fs, path string) error {
 			return errs.WrapUser(err, "unable to touch file")
 		}
 	} else {
-		logrus.Tracef("%s skipped touch", path)
+		logrus.Debugf("%s skipped touch", path)
 	}
 	return nil
 }

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -322,7 +322,7 @@ func touchFile(dest afero.Fs, path string) error {
 			return errs.WrapUser(err, "unable to touch file")
 		}
 	} else {
-		logrus.Infof("%s skipped touch", path)
+		logrus.Tracef("%s skipped touch", path)
 	}
 	return nil
 }


### PR DESCRIPTION
### Summary
Whenever fogg apply is run, the entire output looks like something like:

~~~
...
INFO terraform/modules/domain-redirect/outputs.tf skipped touch 
INFO terraform/modules/domain-redirect/variables.tf skipped touch
INFO terraform/modules/netvr-server/README.md skipped 
INFO terraform/modules/netvr-server/fogg.tf templated 
INFO terraform/modules/netvr-server/main.tf skipped touch 
INFO terraform/modules/netvr-server/outputs.tf skipped touch 
INFO terraform/modules/netvr-server/variables.tf skipped touch 
...
~~~

Which isn't very helpful. It makes it difficult to see what actually was changed. This PR makes the "skipped touch" log line a debug level so it doesn't bog down the normal standard output of the tool, but is visible when needed for debugging.
