### PR TITLE
fix: Backend Workspaces is a block, not argument

### DIFF
--- a/templates/templates/common/backends.tmpl
+++ b/templates/templates/common/backends.tmpl
@@ -11,7 +11,7 @@
   {{ else if eq .Kind "remote" }}
     hostname = "{{ .Remote.HostName }}"
     organization = "{{ .Remote.Organization }}"
-    workspaces = {
+    workspaces {
       name = "{{ .Remote.Workspace }}"
     }
   {{ end }}

--- a/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
@@ -7,7 +7,7 @@ terraform {
 
     hostname     = "tfe.example.com"
     organization = "test-org"
-    workspaces = {
+    workspaces {
       name = "accounts-acct1"
     }
 

--- a/testdata/remote_backend_yaml/terraform/global/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/global/fogg.tf
@@ -7,7 +7,7 @@ terraform {
 
     hostname     = "tfe.example.com"
     organization = "test-org"
-    workspaces = {
+    workspaces {
       name = "global"
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -16,7 +16,7 @@ terraform {
 
     hostname     = "example.com"
     organization = "foo"
-    workspaces = {
+    workspaces {
       name = "staging-comp1"
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -16,7 +16,7 @@ terraform {
 
     hostname     = "example.com"
     organization = "foo"
-    workspaces = {
+    workspaces {
       name = "staging-comp2"
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -16,7 +16,7 @@ terraform {
 
     hostname     = "example.com"
     organization = "foo"
-    workspaces = {
+    workspaces {
       name = "staging-vpc"
     }
 


### PR DESCRIPTION
### Summary
Backend workspaces should be a block not an argument. https://www.terraform.io/language/settings/backends/configuration

### Test Plan
golden files updated

### References
https://www.terraform.io/language/settings/backends/configuration
