### PR TITLE
feat: Optimize Github Actions CI

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -11,6 +11,11 @@ env:
 {{- end }}
 {{- end }}
 
+# cancel old runs if we push new commits to the same ref
+concurrency:
+  group: {{ "${{ github.ref }}" }}
+  cancel-in-progress: true
+
 jobs:
 {{- range $idx, $testBucket := $githubActionsCI.TestBuckets }}
   terraform_{{$idx}}:
@@ -62,8 +67,19 @@ jobs:
       - run: aws configure set profile.{{ $profileName }}.source_profile _idacct
       - run: aws --profile {{ $profileName }} sts get-caller-identity
 {{- end }}
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
   {{- range $component := $testBucket }}
-      - run: |
+      - name: {{ $component.Dir }}
+        if: {{ "${{ steps.filter.outputs.terraform == 'true' }}" }}
+        run: |
           cd {{ $component.Dir }}
           make  {{ $component.Command }}
   {{- end }}

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -3,6 +3,11 @@
 
 on: push
 
+# cancel old runs if we push new commits to the same ref
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   terraform_0:
     runs-on: ubuntu-latest
@@ -34,7 +39,18 @@ jobs:
             git status
             exit 1
           fi
-      - run: |
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
+      - name: terraform/global
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/global
           make  lint
   terraform_1:
@@ -67,6 +83,15 @@ jobs:
             git status
             exit 1
           fi
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
   terraform_2:
     runs-on: ubuntu-latest
     steps:
@@ -97,6 +122,15 @@ jobs:
             git status
             exit 1
           fi
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
   terraform_3:
     runs-on: ubuntu-latest
     steps:
@@ -127,6 +161,15 @@ jobs:
             git status
             exit 1
           fi
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
   terraform_4:
     runs-on: ubuntu-latest
     steps:
@@ -157,6 +200,15 @@ jobs:
             git status
             exit 1
           fi
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
   terraform_5:
     runs-on: ubuntu-latest
     steps:
@@ -187,6 +239,15 @@ jobs:
             git status
             exit 1
           fi
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
   terraform_6:
     runs-on: ubuntu-latest
     steps:
@@ -217,3 +278,12 @@ jobs:
             git status
             exit 1
           fi
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -5,6 +5,11 @@ on: push
 env:
     FOO: bar
 
+# cancel old runs if we push new commits to the same ref
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   terraform_0:
     runs-on: ubuntu-latest
@@ -42,39 +47,72 @@ jobs:
       - run: aws configure set profile.profile.role_arn arn:aws:iam::456:role/foo
       - run: aws configure set profile.profile.source_profile _idacct
       - run: aws --profile profile sts get-caller-identity
-      - run: |
+      # we only run the following if there are changes in the terraform/* directory
+      # to optimize CI time
+      # can use this filter to decide whether or not to run linters or tests.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'terraform/**'
+      - name: terraform/accounts/bar
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/accounts/bar
           make  lint
-      - run: |
+      - name: terraform/accounts/foo
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/accounts/foo
           make  lint
-      - run: |
+      - name: terraform/global
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/global
           make  lint
-      - run: |
+      - name: terraform/modules/my_module
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/modules/my_module
           make  check
-      - run: |
+      - name: terraform/envs/prod/datadog
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/prod/datadog
           make  lint
-      - run: |
+      - name: terraform/envs/prod/hero
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/prod/hero
           make  lint
-      - run: |
+      - name: terraform/envs/prod/okta
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/prod/okta
           make  lint
-      - run: |
+      - name: terraform/envs/prod/sentry
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/prod/sentry
           make  lint
-      - run: |
+      - name: terraform/envs/prod/vpc
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/prod/vpc
           make  lint
-      - run: |
+      - name: terraform/envs/staging/comp1
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/staging/comp1
           make  lint
-      - run: |
+      - name: terraform/envs/staging/comp2
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/staging/comp2
           make  lint
-      - run: |
+      - name: terraform/envs/staging/vpc
+        if: ${{ steps.filter.outputs.terraform == 'true' }}
+        run: |
           cd terraform/envs/staging/vpc
           make  lint


### PR DESCRIPTION
### Summary
2 changes:
- if we push a new change to a ref, cancel previous executions so we don't waste minutes
- if no terraform/** files change, don't run terraform linting

