### PR TITLE
chore: Add darwin/arm64 to downloadable architectures

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -65,6 +65,7 @@ is_supported_platform() {
     darwin/amd64) found=0 ;;
     linux/amd64) found=0 ;;
     windows/amd64) found=0 ;;
+    darwin/arm64) found=0;;
   esac
   return $found
 }

--- a/download.sh
+++ b/download.sh
@@ -65,7 +65,7 @@ is_supported_platform() {
     darwin/amd64) found=0 ;;
     linux/amd64) found=0 ;;
     windows/amd64) found=0 ;;
-    darwin/arm64) found=0;;
+    darwin/arm64) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
### Summary
We release tars for darwin-arm64 architectures, however the download.sh script does not have this hardcoded.

### Test Plan
Confirmed that this works via command line on a Darwin-ARM64 device.
