### PR TITLE
feat: Use tflint config file if present

### DIFF
--- a/templates/templates/repo/scripts/component.mk
+++ b/templates/templates/repo/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/auth0_provider_yaml/scripts/component.mk
+++ b/testdata/auth0_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/bless_provider_yaml/scripts/component.mk
+++ b/testdata/bless_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/circleci/scripts/component.mk
+++ b/testdata/circleci/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/github_actions/scripts/component.mk
+++ b/testdata/github_actions/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/github_provider_yaml/scripts/component.mk
+++ b/testdata/github_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/okta_provider_yaml/scripts/component.mk
+++ b/testdata/okta_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/remote_backend_yaml/scripts/component.mk
+++ b/testdata/remote_backend_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/snowflake_provider_yaml/scripts/component.mk
+++ b/testdata/snowflake_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/tfe_provider_yaml/scripts/component.mk
+++ b/testdata/tfe_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/v2_full_yaml/scripts/component.mk
+++ b/testdata/v2_full_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/v2_minimal_valid_yaml/scripts/component.mk
+++ b/testdata/v2_minimal_valid_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 

--- a/testdata/v2_no_aws_provider_yaml/scripts/component.mk
+++ b/testdata/v2_no_aws_provider_yaml/scripts/component.mk
@@ -2,7 +2,15 @@
 # Make improvements in fogg, so that everyone can benefit.
 
 SELF_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT:=$(shell dirname $(SELF_DIR))
 CHECK_PLANFILE_PATH ?= check-plan.output
+
+TFLINT_CONFIG := $(ROOT)/.tflint.hcl
+TFLINT_CONFIG_EXISTS := 1
+
+ifeq ("$(wildcard $(TFLINT_CONFIG))","")
+	TFLINT_CONFIG_EXISTS := 0
+endif
 
 include $(SELF_DIR)/common.mk
 
@@ -24,11 +32,13 @@ lint: lint-terraform-fmt lint-tflint ## run all linters for this component
 .PHONY: lint
 
 lint-tflint: ## run the tflint linter for this component
-	@printf "tflint: "
-ifeq ($(TFLINT_ENABLED),1)
-	@tflint || exit $$?;
-else
+	@printf "tflint:"
+ifneq ($(TFLINT_ENABLED),1)
 	@echo "disabled"
+else ifeq ($(TFLINT_CONFIG_EXISTS), 1)
+	@tflint --config $(ROOT)/.tflint.hcl || exit $$?
+else ifeq ($(TFLINT_CONFIG_EXISTS), 0) 
+	@tflint || exit $$?;	
 endif
 .PHONY: lint-tflint
 


### PR DESCRIPTION
### Summary
Allow the `make lint` function to use `tflint.hcl` file if present in the repository.

### Test Plan
Make operation verified locally.
