### PR TITLE
fix: circleci template yml installs terraform-docs

### DIFF
--- a/templates/templates/circleci/.circleci/config.yml.tmpl
+++ b/templates/templates/circleci/.circleci/config.yml.tmpl
@@ -28,7 +28,7 @@ jobs:
             curl -sSLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64.tar.gz
             tar -xzf terraform-docs.tar.gz
             chmod +x terraform-docs
-            echo "$PWD" >> $GITHUB_PATH
+            export PATH="$PATH:$PWD"
       - run: python3 -m venv venv
       - run: . venv/bin/activate
       - run: pip install awscli --upgrade --user


### PR DESCRIPTION
### Summary
A description of changes or issues addressed by this PR. Provide links to relevant PRs if any.
https://github.com/chanzuckerberg/fogg/pull/619

$GITHUB_PATH is a github actions specific env var and doesn't work for circleci. Fix by just adding it to the path

### Test Plan
Say unittests, or list out steps to verify changes.
Confirm that it works by manually editing my circleci config in https://github.com/FB-PLP/terraform-infra-management/pull/1681

### References
(Optional) Additional links to provide more context.
