### PR TITLE
chore: mark fogg_ci.yml as auto generated

### DIFF
--- a/templates/templates/repo/.gitattributes
+++ b/templates/templates/repo/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/auth0_provider_yaml/.gitattributes
+++ b/testdata/auth0_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/bless_provider_yaml/.gitattributes
+++ b/testdata/bless_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/circleci/.gitattributes
+++ b/testdata/circleci/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/github_actions/.gitattributes
+++ b/testdata/github_actions/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/github_provider_yaml/.gitattributes
+++ b/testdata/github_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/okta_provider_yaml/.gitattributes
+++ b/testdata/okta_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/remote_backend_yaml/.gitattributes
+++ b/testdata/remote_backend_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/snowflake_provider_yaml/.gitattributes
+++ b/testdata/snowflake_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/tfe_provider_yaml/.gitattributes
+++ b/testdata/tfe_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/v2_full_yaml/.gitattributes
+++ b/testdata/v2_full_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/v2_minimal_valid_yaml/.gitattributes
+++ b/testdata/v2_minimal_valid_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated

--- a/testdata/v2_no_aws_provider_yaml/.gitattributes
+++ b/testdata/v2_no_aws_provider_yaml/.gitattributes
@@ -3,3 +3,4 @@ Makefile linguist-generated
 .travis.yml linguist-generated
 .circleci/config.yml linguist-generated
 .terraformignore linguist-generated
+.github/workflows/fogg_ci.yml linguist-generated


### PR DESCRIPTION
### Summary
The new fogg verision introduces a `fogg_ci.yml` for Github Actions. Adding new components to fogg also introduces changes to that file, similar to `fogg.tf`. Given that it's all auto generated, we can mark the file as such so its hidden during PR review. 

### Test Plan
Updated existing tests, tests should pass.

### References
(Optional) Additional links to provide more context.
