### PR TITLE
fix: treat AWS account IDs as strings

### DIFF
--- a/templates/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/templates/component/terraform/fogg.tf.tmpl
@@ -159,7 +159,7 @@ variable "aws_accounts" {
   type =  map(string)
   default = {
   {{ range $account, $id := .Accounts }}
-    {{ $account }} = {{ $id }}
+    {{ $account }} = "{{ $id }}"
   {{ end }}
   }
 }

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: aws configure set aws_access_key_id     ${{ secrets.IDACCT_AWS_ACCESS_KEY_ID }}     --profile _idacct
       - run: aws configure set aws_secret_access_key ${{ secrets.IDACCT_AWS_SECRET_ACCESS_KEY }} --profile _idacct
       - run: aws --profile _idacct sts get-caller-identity
-      - run: aws configure set profile.profile.role_arn arn:aws:iam::456:role/foo
+      - run: aws configure set profile.profile.role_arn arn:aws:iam::00456:role/foo
       - run: aws configure set profile.profile.source_profile _idacct
       - run: aws --profile profile sts get-caller-identity
       # we only run the following if there are changes in the terraform/* directory

--- a/testdata/v2_full_yaml/fogg.yml
+++ b/testdata/v2_full_yaml/fogg.yml
@@ -2,7 +2,7 @@ accounts:
   bar:
     providers:
       aws:
-        account_id: 456
+        account_id: 00456
         additional_regions:
           - us-east-1
           - us-east-2
@@ -44,7 +44,7 @@ defaults:
   project: proj
   providers:
     aws:
-      account_id: 456
+      account_id: 00456
       profile: profile
       region: us-west-2
       version: 0.12.0

--- a/testdata/v2_full_yaml/terraform/accounts/bar/Makefile
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/Makefile
@@ -11,7 +11,7 @@ export AWS_BACKEND_PROFILE := profile
 
 
 
-export AWS_PROVIDER_ROLE_ARN := arn:aws:iam::456:role/foo
+export AWS_PROVIDER_ROLE_ARN := arn:aws:iam::00456:role/foo
 
 
 

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -6,10 +6,10 @@ provider "aws" {
 
 
   assume_role {
-    role_arn = "arn:aws:iam::456:role/foo"
+    role_arn = "arn:aws:iam::00456:role/foo"
   }
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -124,10 +124,10 @@ provider "aws" {
 
 
   assume_role {
-    role_arn = "arn:aws:iam::456:role/foo"
+    role_arn = "arn:aws:iam::00456:role/foo"
   }
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 
 
@@ -137,10 +137,10 @@ provider "aws" {
 
 
   assume_role {
-    role_arn = "arn:aws:iam::456:role/foo"
+    role_arn = "arn:aws:iam::00456:role/foo"
   }
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 
 
@@ -306,9 +306,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -148,9 +148,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -223,9 +223,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -146,9 +146,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -226,9 +226,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -156,9 +156,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -216,9 +216,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -184,9 +184,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -184,9 +184,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 
@@ -184,9 +184,9 @@ variable "aws_accounts" {
   type = map(string)
   default = {
 
-    bar = 456
+    bar = "00456"
 
-    foo = 123
+    foo = "123"
 
   }
 }

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -5,7 +5,7 @@ provider "aws" {
   region  = "us-west-2"
   profile = "profile"
 
-  allowed_account_ids = [456]
+  allowed_account_ids = [00456]
 }
 # Aliased Providers (for doing things in every region).
 


### PR DESCRIPTION
### Summary
This PR fixes a bug in that AWS account IDs were being templated as numbers. This is a problem when AWS account IDs start with zeroes because terraform will cast them to string without the leading zeros. For instance, `0000000000000009273135997` will be transformed to `"9273135997"`.

### Test Plan
* make update-golden-files
* make test

### References
* [failed terraform plan](https://si.prod.tfe.czi.technology/app/shared-infra/workspaces/accounts-czi-id/runs/run-D1ndxWxfEBU3V5uq)