### PR TITLE
feat!: Use Snowflake-Lab version of Terraform Snowflake provider

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -674,7 +674,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		}
 
 		providerVersions["snowflake"] = ProviderVersion{
-			Source:  "chanzuckerberg/snowflake",
+			Source:  "Snowflake-Labs/snowflake",
 			Version: snowflakeConfig.Version,
 		}
 	}

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -58,7 +58,7 @@ terraform {
     }
 
     snowflake = {
-      source = "chanzuckerberg/snowflake"
+      source = "Snowflake-Labs/snowflake"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -58,7 +58,7 @@ terraform {
     }
 
     snowflake = {
-      source = "chanzuckerberg/snowflake"
+      source = "Snowflake-Labs/snowflake"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
@@ -58,7 +58,7 @@ terraform {
     }
 
     snowflake = {
-      source = "chanzuckerberg/snowflake"
+      source = "Snowflake-Labs/snowflake"
 
     }
 


### PR DESCRIPTION
### Summary
In transitioning support of the Snowflake Terraform provider to Snowflake, the hardcoded organization needed to be replaced.

### Test Plan
```
make update-golden-files
go get -u ./...
make test
go run main.go
go mod tidy
```
### References
[ONCALL-56]


[ONCALL-56]: https://czi-eng.atlassian.net/browse/ONCALL-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ