### PR TITLE
chore: Have Git ignore .terraform.lock.hcl

### DIFF
--- a/templates/templates/repo/.gitignore
+++ b/templates/templates/repo/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/auth0_provider_yaml/.gitignore
+++ b/testdata/auth0_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/bless_provider_yaml/.gitignore
+++ b/testdata/bless_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/circleci/.gitignore
+++ b/testdata/circleci/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/github_actions/.gitignore
+++ b/testdata/github_actions/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/github_provider_yaml/.gitignore
+++ b/testdata/github_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/okta_provider_yaml/.gitignore
+++ b/testdata/okta_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/remote_backend_yaml/.gitignore
+++ b/testdata/remote_backend_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/snowflake_provider_yaml/.gitignore
+++ b/testdata/snowflake_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/tfe_provider_yaml/.gitignore
+++ b/testdata/tfe_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/v2_full_yaml/.gitignore
+++ b/testdata/v2_full_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/v2_minimal_valid_yaml/.gitignore
+++ b/testdata/v2_minimal_valid_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/testdata/v2_no_aws_provider_yaml/.gitignore
+++ b/testdata/v2_no_aws_provider_yaml/.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*.backup
 *.tfstate.backup
 *tfvars
+.terraform.lock.hcl
 
 # Module directory
 .terraform/


### PR DESCRIPTION
### Summary
`.terraform.lock.hcl` files are created locally whenever a user needs to manage TFE state. These should not be pushed so the state isn't locked inadvertently.

### Test Plan
```
make update-golden-files
make test
```

### References
[ONCALL-60]


[ONCALL-60]: https://czi-eng.atlassian.net/browse/ONCALL-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ