### PR TITLE
feat: add okta/okta provider

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -171,6 +171,10 @@ var utilityProviders = map[string]ProviderVersion{
 		Source:  "bwoznicki/assert",
 		Version: ptr.String("~> 0.0.1"),
 	},
+	"okta-head": {
+		Source:  "okta/okta",
+		Version: ptr.String("~> 3.30"),
+	},
 }
 
 //AWSProvider represents AWS provider configuration

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -55,6 +55,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -55,6 +55,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/auth0_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/global/fogg.tf
@@ -55,6 +55,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -70,6 +70,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -70,6 +70,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/bless_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/global/fogg.tf
@@ -70,6 +70,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/circleci/terraform/global/fogg.tf
+++ b/testdata/circleci/terraform/global/fogg.tf
@@ -44,6 +44,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/github_actions/terraform/global/fogg.tf
+++ b/testdata/github_actions/terraform/global/fogg.tf
@@ -44,6 +44,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -54,6 +54,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -54,6 +54,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/github_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/global/fogg.tf
@@ -54,6 +54,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -56,6 +56,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -56,6 +56,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/okta_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/global/fogg.tf
@@ -56,6 +56,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
@@ -42,6 +42,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/remote_backend_yaml/terraform/global/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/global/fogg.tf
@@ -42,6 +42,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -50,6 +50,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -50,6 +50,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
@@ -50,6 +50,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -47,6 +47,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -44,6 +44,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/tfe_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/global/fogg.tf
@@ -47,6 +47,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -206,6 +206,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -76,6 +76,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -67,6 +67,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -74,6 +74,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
@@ -70,6 +70,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
@@ -63,6 +63,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
@@ -60,6 +60,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -58,6 +58,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -58,6 +58,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -58,6 +58,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -60,6 +60,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
@@ -44,6 +44,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -44,6 +44,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
@@ -44,6 +44,13 @@ terraform {
 
     }
 
+    okta-head = {
+      source = "okta/okta"
+
+      version = "~> 3.30"
+
+    }
+
     random = {
       source = "hashicorp/random"
 


### PR DESCRIPTION
### Summary
This PR adds the real head okta/okta Terraform provider as one of the utility providers that fogg produces. This is helpful so that we can have an alias to the head set of changes from the Okta terraform provider and also use an internal fork of the Okta terraform provider to make improvements.

### Test Plan
Unit tests

### References
* https://github.com/hashicorp/terraform/issues/28823#issuecomment-857236321
* https://github.com/okta/terraform-provider-okta/blob/3883831416240b3d99108b533e4b7ad3a16cd68e/okta/resource_okta_app_oauth.go#L422-L425
* https://github.com/okta/terraform-provider-okta/blob/3883831416240b3d99108b533e4b7ad3a16cd68e/okta/app.go#L61