### PR TITLE
feat: CDI-199 Change databricks provider source to databricks/databricks

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -753,7 +753,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 	databricksConfig := v2.ResolveDatabricksProvider(commons...)
 	if databricksConfig != nil {
 		providerVersions["databricks"] = ProviderVersion{
-			Source:  "databrickslabs/databricks",
+			Source:  "databricks/databricks",
 			Version: databricksConfig.Version,
 		}
 	}


### PR DESCRIPTION
### Summary
Bump `databricks` provider from `databrickslabs/databricks` to `databricks/databricks`, given that the provider is being moved: https://github.com/databricks/terraform-provider-databricks/blob/master/CHANGELOG.md

### Test Plan
Ran `make update-golden-files` successfully

### References
(Optional) Additional links to provide more context.
