### PR TITLE
feat: allowing fogg to run with a github app token

### DIFF
--- a/util/module_storage_test.go
+++ b/util/module_storage_test.go
@@ -61,6 +61,20 @@ func TestMakeDownloader(t *testing.T) {
 	r.Equal(fmt.Sprintf("git::https://%s@github.com/chanzuckerberg/test-repo//terraform/modules/eks-airflow?ref=v0.80.0", creds), downloader.Source)
 }
 
+func TestMakeDownloaderGithubApp(t *testing.T) {
+	r := require.New(t)
+	creds := "REDACTED"
+	downloader, err := MakeDownloader("git@github.com:chanzuckerberg/test-repo//terraform/modules/eks-airflow?ref=v0.80.0")
+	r.NoError(err)
+	r.Equal("git@github.com:chanzuckerberg/test-repo//terraform/modules/eks-airflow?ref=v0.80.0", downloader.Source)
+
+	os.Setenv("FOGG_GITHUBAPPTOKEN", creds)
+	defer os.Unsetenv("FOGG_GITHUBAPPTOKEN")
+	downloader, err = MakeDownloader("git@github.com:chanzuckerberg/test-repo//terraform/modules/eks-airflow?ref=v0.80.0")
+	r.NoError(err)
+	r.Equal(fmt.Sprintf("git::https://x-access-token:%s@github.com/chanzuckerberg/test-repo//terraform/modules/eks-airflow?ref=v0.80.0", creds), downloader.Source)
+}
+
 func TestConvertSSHToHTTP(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
### Summary
This PR allows Github Actions utilize installation tokens as an authentication mechanism as opposed to SSH keys.

### Test Plan
Unittests

### References
* https://github.com/tibdex/github-app-token