### PR TITLE
fix: cache breaking with github app creds

### DIFF
--- a/util/module_storage_test.go
+++ b/util/module_storage_test.go
@@ -75,6 +75,13 @@ func TestMakeDownloaderGithubApp(t *testing.T) {
 	r.Equal(fmt.Sprintf("git::https://x-access-token:%s@github.com/chanzuckerberg/test-repo//terraform/modules/eks-airflow?ref=v0.80.0", creds), downloader.Source)
 }
 
+func TestRedactURL(t *testing.T) {
+	r := require.New(t)
+
+	rurl := redactCredentials("git::https://x-access-token:1234@github.com/chanzuckerberg/shared-infra")
+	r.Equal("git::https://REDACTED:REDACTED@github.com/chanzuckerberg/shared-infra", rurl)
+}
+
 func TestConvertSSHToHTTP(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
### Summary
This PR fixes an issue where the cache was breaking when using Github App credentials because Github App credentials are 1 time use and each time we'd call fogg with the credentials, the full source URL would be different. To solve this, we change the user and password field of the URL to REDACTED:REDACTED so the URL for the same source will be the same.

### Test Plan
Unittests
