### PR TITLE
fix: issue where the default version is not used

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -119,9 +119,12 @@ type TFEWorkspace struct {
 	RemoteApply          *bool                 `json:"remote_apply,omitempty"`
 }
 
-func MakeTFEWorkspace() *TFEWorkspace {
+func MakeTFEWorkspace(tfVersion string) *TFEWorkspace {
 	defaultTriggerPrefixes := make([]string, 0)
-	defaultTerraformVersion := "1.2.6"
+	defaultTerraformVersion := tfVersion
+	if defaultTerraformVersion == "" {
+		defaultTerraformVersion = "1.2.6"
+	}
 	defaultGithubBranch := "main"
 	defaultAutoApply := true
 	defaultRemoteApply := false
@@ -138,7 +141,7 @@ func updateLocalsFromPlan(locals *LocalsTFE, plan *plan.Plan) {
 	// if there is a planned env or account that isn't in the locals, add it
 	for accountName := range plan.Accounts {
 		if _, ok := locals.Locals.Accounts[accountName]; !ok {
-			locals.Locals.Accounts[accountName] = MakeTFEWorkspace()
+			locals.Locals.Accounts[accountName] = MakeTFEWorkspace(plan.Global.Common.TerraformVersion)
 		}
 	}
 	for envName := range plan.Envs {
@@ -147,7 +150,7 @@ func updateLocalsFromPlan(locals *LocalsTFE, plan *plan.Plan) {
 		}
 		for componentName := range plan.Envs[envName].Components {
 			if _, ok := locals.Locals.Envs[envName][componentName]; !ok {
-				locals.Locals.Envs[envName][componentName] = MakeTFEWorkspace()
+				locals.Locals.Envs[envName][componentName] = MakeTFEWorkspace(plan.Global.Common.TerraformVersion)
 			}
 		}
 	}

--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -68,7 +68,7 @@ func makeTestCases(tests []UploadLocalsTestCaseSimple) ([]UploadLocalsTestCase, 
 
 		localAccounts := make(map[string]*TFEWorkspace, 0)
 		for _, local := range test.localsAccounts {
-			localAccounts[local] = MakeTFEWorkspace()
+			localAccounts[local] = MakeTFEWorkspace("1.2.6")
 		}
 		localEnvs := make(map[string]map[string]*TFEWorkspace, 0)
 		for _, local := range test.localEnvs {
@@ -77,7 +77,7 @@ func makeTestCases(tests []UploadLocalsTestCaseSimple) ([]UploadLocalsTestCase, 
 				return nil, errors.New("env needs to be of the form env/component")
 			}
 			component := map[string]*TFEWorkspace{}
-			component[splits[1]] = MakeTFEWorkspace()
+			component[splits[1]] = MakeTFEWorkspace("1.2.6")
 			localEnvs[splits[0]] = component
 		}
 		locals := LocalsTFE{


### PR DESCRIPTION
### Summary
This PR uses the default version from the fogg.yml file when selecting the version to use in the TFE workspace. 

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
