### PR TITLE
fix: remote apply default true

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -127,7 +127,7 @@ func MakeTFEWorkspace(tfVersion string) *TFEWorkspace {
 	}
 	defaultGithubBranch := "main"
 	defaultAutoApply := true
-	defaultRemoteApply := false
+	defaultRemoteApply := true
 	return &TFEWorkspace{
 		TriggerPrefixes:  &defaultTriggerPrefixes,
 		TerraformVersion: &defaultTerraformVersion,


### PR DESCRIPTION
### Summary
We want the default remote apply behavior to be true so that all plans/applies happen on TFE and not locally.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
