### PR TITLE
feat: make auth0 provider configurable

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -163,6 +163,7 @@ type CommonProvider struct {
 type Auth0Provider struct {
 	Version *string `yaml:"version,omitempty"`
 	Domain  *string `yaml:"domain,omitempty"`
+	Source  *string `yaml:"source,omitempty"`
 }
 
 // OktaProvider is an okta provider

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -80,7 +80,7 @@ func ResolveStringMap(getter func(Common) map[string]string, commons ...Common) 
 }
 
 func ResolveAuth0Provider(commons ...Common) *Auth0Provider {
-	var domain, version *string
+	var domain, version, source *string
 	for _, c := range commons {
 		if c.Providers == nil || c.Providers.Auth0 == nil {
 			continue
@@ -92,10 +92,14 @@ func ResolveAuth0Provider(commons ...Common) *Auth0Provider {
 		if c.Providers.Auth0.Domain != nil {
 			domain = c.Providers.Auth0.Domain
 		}
+
+		if c.Providers.Auth0.Source != nil {
+			source = c.Providers.Auth0.Source
+		}
 	}
 
 	if domain != nil && version != nil {
-		return &Auth0Provider{Version: version, Domain: domain}
+		return &Auth0Provider{Version: version, Domain: domain, Source: source}
 	}
 	return nil
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -732,7 +732,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 		}
 
 		providerVersions["auth0"] = ProviderVersion{
-			Source:  "alexkappa/auth0",
+			Source:  "auth0/auth0",
 			Version: auth0Config.Version,
 		}
 	}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -731,8 +731,12 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 			Domain: *auth0Config.Domain,
 		}
 
+		defaultSource := "alexkappa/auth0"
+		if auth0Config.Source == nil {
+			auth0Config.Source = &defaultSource
+		}
 		providerVersions["auth0"] = ProviderVersion{
-			Source:  "auth0/auth0",
+			Source:  *auth0Config.Source,
 			Version: auth0Config.Version,
 		}
 	}

--- a/testdata/auth0_provider_yaml/fogg.yml
+++ b/testdata/auth0_provider_yaml/fogg.yml
@@ -1,29 +1,35 @@
 {
-    "version": 2,
-    "defaults": {
-        "providers": {
-            "auth0": {
-                "domain": "adomain",
-                "version": "aversion"
-            }
+  "version": 2,
+  "defaults":
+    {
+      "providers":
+        {
+          "auth0":
+            {
+              "domain": "adomain",
+              "version": "aversion"
+            },
         },
-        "backend": {
-            "bucket": "bucket",
-            "region": "region",
-            "profile": "foofoo"
+      "backend":
+        { "bucket": "bucket", "region": "region", "profile": "foofoo" },
+      "project": "foofoo",
+      "owner": "foo@example.com",
+      "terraform_version": "1.1.1",
+    },
+  "accounts":
+    {
+      "foo":
+        {
+          "providers":
+            {
+              "auth0":
+                {
+                  "domain": "adomain",
+                  "version": "aversion",
+                  "source": 'blah/blah',
+                },
+            },
         },
-        "project": "foofoo",
-        "owner": "foo@example.com",
-        "terraform_version": "1.1.1"
     },
-    "accounts": {
-        "foo": {}
-    },
-    "envs": {
-        "bar": {
-            "components": {
-                "bam": {}
-            }
-        }
-    }
+  "envs": { "bar": { "components": { "bam": {} } } },
 }

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "alexkappa/auth0"
+      source = "blah/blah"
 
       version = "aversion"
 

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "alexkappa/auth0"
+      source = "auth0/auth0"
 
       version = "aversion"
 

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "auth0/auth0"
+      source = "alexkappa/auth0"
 
       version = "aversion"
 

--- a/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "alexkappa/auth0"
+      source = "auth0/auth0"
 
       version = "aversion"
 

--- a/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "auth0/auth0"
+      source = "alexkappa/auth0"
 
       version = "aversion"
 

--- a/testdata/auth0_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/global/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "alexkappa/auth0"
+      source = "auth0/auth0"
 
       version = "aversion"
 

--- a/testdata/auth0_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/global/fogg.tf
@@ -35,7 +35,7 @@ terraform {
     }
 
     auth0 = {
-      source = "auth0/auth0"
+      source = "alexkappa/auth0"
 
       version = "aversion"
 


### PR DESCRIPTION
### Summary
This PR makes the auth0 provider configurable so that the user can change the host based on their provider version. This should allow you to do something like:

~~~
dev:
    providers:
      auth0:
        version: 0.37.1   
        source: "auth0/auth0". 
        domain: mydomain.com
~~~

### Test Plan
* auth0_config testdata section
