### PR TITLE
chore: Update utility providers

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -151,7 +151,7 @@ type ProviderVersion struct {
 var utilityProviders = map[string]ProviderVersion{
 	"random": {
 		Source:  "hashicorp/random",
-		Version: ptr.String("~> 2.2"),
+		Version: ptr.String("~> 3.4"),
 	},
 	"archive": {
 		Source:  "hashicorp/archive",

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -153,10 +153,6 @@ var utilityProviders = map[string]ProviderVersion{
 		Source:  "hashicorp/random",
 		Version: ptr.String("~> 2.2"),
 	},
-	"template": {
-		Source:  "hashicorp/template",
-		Version: ptr.String("~> 2.2"),
-	},
 	"archive": {
 		Source:  "hashicorp/archive",
 		Version: ptr.String("~> 2.0"),

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -65,14 +65,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -65,14 +65,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/auth0_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/global/fogg.tf
@@ -65,14 +65,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -80,14 +80,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -80,14 +80,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/bless_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/global/fogg.tf
@@ -80,14 +80,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/circleci/terraform/global/fogg.tf
+++ b/testdata/circleci/terraform/global/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/github_actions/terraform/global/fogg.tf
+++ b/testdata/github_actions/terraform/global/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -64,14 +64,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -64,14 +64,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/github_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/global/fogg.tf
@@ -64,14 +64,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -66,14 +66,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -66,14 +66,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/okta_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/global/fogg.tf
@@ -66,14 +66,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
@@ -52,14 +52,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/remote_backend_yaml/terraform/global/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/global/fogg.tf
@@ -52,14 +52,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -60,19 +60,12 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 
     snowflake = {
       source = "Snowflake-Labs/snowflake"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -60,19 +60,12 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 
     snowflake = {
       source = "Snowflake-Labs/snowflake"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
@@ -60,19 +60,12 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 
     snowflake = {
       source = "Snowflake-Labs/snowflake"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
 
     }
 

--- a/testdata/tfe_config/terraform/accounts/account/fogg.tf
+++ b/testdata/tfe_config/terraform/accounts/account/fogg.tf
@@ -72,14 +72,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/tfe_config/terraform/global/fogg.tf
+++ b/testdata/tfe_config/terraform/global/fogg.tf
@@ -72,14 +72,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/tfe_config/terraform/tfe/fogg.tf
+++ b/testdata/tfe_config/terraform/tfe/fogg.tf
@@ -76,14 +76,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -57,14 +57,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/tfe_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/global/fogg.tf
@@ -57,14 +57,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -216,14 +216,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -86,14 +86,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -77,14 +77,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -84,14 +84,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
@@ -80,14 +80,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
@@ -73,7 +73,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 
@@ -81,13 +81,6 @@ terraform {
       source = "jianyuan/sentry"
 
       version = "1.2.3"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
@@ -70,14 +70,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -68,14 +68,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -68,14 +68,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -68,14 +68,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -70,14 +70,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/accounts/bar/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
@@ -54,14 +54,7 @@ terraform {
     random = {
       source = "hashicorp/random"
 
-      version = "~> 2.2"
-
-    }
-
-    template = {
-      source = "hashicorp/template"
-
-      version = "~> 2.2"
+      version = "~> 3.4"
 
     }
 


### PR DESCRIPTION
### Summary

some utility providers hardcoded in fogg don't support arm.

- deprecate template provider (replaced with 0.12 functionality)
- update random provider to latest version
- update golden test files 

### Test Plan
no changes to tests

