### PR TITLE
feat: terraform_unused_declarations warning in latest tflint version

### DIFF
--- a/templates/templates/component/terraform/fogg.tf.tmpl
+++ b/templates/templates/component/terraform/fogg.tf.tmpl
@@ -67,29 +67,34 @@ terraform {
   {{ end}}
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    =  string
   default = "{{ .Env }}"
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    =  string
   default = "{{ .Project }}"
 }
 
 {{if .ProviderConfiguration.AWS}}
+  # tflint-ignore: terraform_unused_declarations
   variable "region" {
     type    =  string
     default = "{{ .ProviderConfiguration.AWS.Region }}"
   }
 {{ end }}
 
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type =  string
   default = "{{ .Name }}"
 }
 
 {{ if (avail "Account" .) }}
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type =  string
   default = "{{ .Account }}"
@@ -97,17 +102,20 @@ variable "account" {
 {{ end }}
 
 {{ if .ProviderConfiguration.AWS }}{{ if .ProviderConfiguration.AWS.Profile }}
+  # tflint-ignore: terraform_unused_declarations
   variable "aws_profile" {
     type =  string
     default =  "{{ .ProviderConfiguration.AWS.Profile }}"
   }
 {{ end }}{{ end }}
 
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type =  string
   default = "{{ .Owner }}"
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type =  object({project: string, env: string, service: string, owner: string, managedBy: string})
   default = {
@@ -120,6 +128,7 @@ variable "tags" {
 }
 
 {{ range $key, $val := .ExtraVars }}
+# tflint-ignore: terraform_unused_declarations
 variable "{{ $key }}" {
   type =  string
   default = "{{ $val }}"
@@ -128,6 +137,7 @@ variable "{{ $key }}" {
 
 {{ if .Global}}
 {{ if .Global.Backend.Kind}}
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "{{ .Global.Backend.Kind }}"
 
@@ -159,6 +169,7 @@ data "terraform_remote_state" "{{ $name }}" {
 }
 {{ end }}
 
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type =  map(string)
   default = {

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -80,26 +80,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -110,6 +116,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -138,6 +145,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -80,22 +80,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bam"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -106,6 +111,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -134,6 +140,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/auth0_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/global/fogg.tf
@@ -80,22 +80,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -106,6 +111,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -93,26 +93,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -123,6 +129,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -151,6 +158,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -93,22 +93,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bam"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -119,6 +124,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -147,6 +153,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/bless_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/global/fogg.tf
@@ -93,22 +93,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -119,6 +124,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/circleci/terraform/global/fogg.tf
+++ b/testdata/circleci/terraform/global/fogg.tf
@@ -69,22 +69,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -95,6 +100,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/github_actions/terraform/global/fogg.tf
+++ b/testdata/github_actions/terraform/global/fogg.tf
@@ -69,22 +69,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -95,6 +100,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -81,26 +81,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -111,6 +117,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -139,6 +146,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -81,22 +81,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bam"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -107,6 +112,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -135,6 +141,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/github_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/global/fogg.tf
@@ -81,22 +81,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -107,6 +112,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -81,26 +81,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -111,6 +117,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -139,6 +146,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -81,22 +81,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bam"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -107,6 +112,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -135,6 +141,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/okta_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/global/fogg.tf
@@ -81,22 +81,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foofoo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -107,6 +112,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
@@ -67,26 +67,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "acct1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "acct1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -97,6 +103,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -123,6 +130,7 @@ data "terraform_remote_state" "acct1" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/remote_backend_yaml/terraform/global/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/global/fogg.tf
@@ -67,22 +67,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -93,6 +98,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -82,26 +82,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -112,6 +118,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -140,6 +147,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -82,22 +82,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bam"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -108,6 +113,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -136,6 +142,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/main.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/main.tf
@@ -1,0 +1,7 @@
+locals {
+  foo = data.terraform_remote_state.foo
+}
+
+resource random_number foo {
+  name = local.foo
+}

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/main.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/main.tf
@@ -1,7 +1,0 @@
-locals {
-  foo = data.terraform_remote_state.foo
-}
-
-resource random_number foo {
-  name = local.foo
-}

--- a/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
@@ -82,22 +82,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -108,6 +113,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_config/terraform/accounts/account/fogg.tf
+++ b/testdata/tfe_config/terraform/accounts/account/fogg.tf
@@ -87,30 +87,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "account"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "account"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -121,6 +128,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -147,6 +155,7 @@ data "terraform_remote_state" "account" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_config/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/tfe_config/terraform/envs/staging/comp1/fogg.tf
@@ -89,26 +89,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "comp1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -119,6 +125,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -145,6 +152,7 @@ data "terraform_remote_state" "account" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_config/terraform/global/fogg.tf
+++ b/testdata/tfe_config/terraform/global/fogg.tf
@@ -87,26 +87,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -117,6 +123,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_config/terraform/tfe/fogg.tf
+++ b/testdata/tfe_config/terraform/tfe/fogg.tf
@@ -94,26 +94,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -124,14 +130,17 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "TFE_AWS_ACCESS_KEY_ID" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "TFE_AWS_SECRET_ACCESS_KEY" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -79,26 +79,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -109,6 +115,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -137,6 +144,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -69,22 +69,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bam"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -95,6 +100,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -123,6 +129,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/tfe_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/global/fogg.tf
@@ -79,22 +79,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -105,6 +110,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -231,30 +231,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -265,10 +272,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -311,6 +320,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -101,30 +101,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -135,10 +142,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -153,6 +162,7 @@ data "terraform_remote_state" "global" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -94,30 +94,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "prod"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "datadog"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -128,10 +135,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -230,6 +239,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -102,30 +102,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "prod"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "hero"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -136,10 +143,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -154,6 +163,7 @@ data "terraform_remote_state" "global" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
@@ -97,30 +97,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "prod"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "okta"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -131,10 +138,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -233,6 +242,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
@@ -95,30 +95,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "prod"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "sentry"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -129,10 +136,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -161,6 +170,7 @@ data "terraform_remote_state" "hero" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
@@ -85,30 +85,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "prod"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "vpc"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -119,10 +126,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -221,6 +230,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -83,30 +83,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "comp1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -117,10 +124,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar2"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -189,6 +198,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -83,30 +83,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "comp2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -117,10 +124,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar2"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -189,6 +198,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -83,30 +83,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "vpc"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -117,10 +124,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar3"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "s3"
   config = {
@@ -189,6 +198,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -85,30 +85,37 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "region" {
   type    = string
   default = "us-west-2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_profile" {
   type    = string
   default = "profile"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -119,10 +126,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
@@ -69,22 +69,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -95,6 +100,7 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_no_aws_provider_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/accounts/bar/fogg.tf
@@ -67,26 +67,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "bar"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -97,10 +103,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -140,6 +148,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_no_aws_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -67,26 +67,32 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "accounts"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "account" {
   type    = string
   default = "foo"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -97,10 +103,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -140,6 +148,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -67,22 +67,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "comp1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -93,10 +98,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar2"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -162,6 +169,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -67,22 +67,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "comp2"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -93,10 +98,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar2"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -162,6 +169,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -67,22 +67,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = "staging"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "vpc"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -93,10 +98,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar3"
 }
+# tflint-ignore: terraform_unused_declarations
 data "terraform_remote_state" "global" {
   backend = "remote"
   config = {
@@ -162,6 +169,7 @@ data "terraform_remote_state" "foo" {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {

--- a/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
@@ -67,22 +67,27 @@ terraform {
 
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "env" {
   type    = string
   default = ""
 }
+# tflint-ignore: terraform_unused_declarations
 variable "project" {
   type    = string
   default = "proj"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "component" {
   type    = string
   default = "global"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "owner" {
   type    = string
   default = "foo@example.com"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "tags" {
   type = object({ project : string, env : string, service : string, owner : string, managedBy : string })
   default = {
@@ -93,10 +98,12 @@ variable "tags" {
     managedBy = "terraform"
   }
 }
+# tflint-ignore: terraform_unused_declarations
 variable "foo" {
   type    = string
   default = "bar1"
 }
+# tflint-ignore: terraform_unused_declarations
 variable "aws_accounts" {
   type = map(string)
   default = {


### PR DESCRIPTION
### Summary
After updating tflint to the latest version, we were getting a lot of `terraform_unused_declarations` warnings which were throwing people off. We have added a comment above many of the variables in the `fogg.tf` template so that these warnings will go away.

### Test Plan
Ran `update-golden-files` and it applies on the `testdata` envs. We verified by removing one of the comments and running `tflint` to see if it would return a warning. It returned a warning and so we added it back and reran `tflint` and came back clean.

### References
(Optional) Additional links to provide more context.
