### PR TITLE
fix: loosen upgrade options for okta-head provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/chanzuckerberg/fogg
 
-go 1.20
+go 1.21
+
+toolchain go1.21.0
 
 replace github.com/spf13/afero => github.com/chanzuckerberg/afero v0.0.0-20190514223411-36a9495a9b51
 

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190103054945-8205d1f41e70/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible/go.mod h1:LDQHRZylxvcg8H7wBIDfvO5g/cy4/sz1iucBlc2l3Jw=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antchfx/xpath v0.0.0-20190129040759-c8489ed3251e/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -255,6 +256,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
@@ -318,6 +320,7 @@ github.com/dylanmei/iso8601 v0.1.0/go.mod h1:w9KhXSgIyROl1DefbMYIE7UVSIvELTbMrCf
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
+github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
@@ -340,6 +343,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
+github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
@@ -347,6 +351,7 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmS
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
+github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.11.0 h1:XIZc1p+8YzypNr34itUfSvYJcv+eYdTnTvOZ2vD3cA4=
 github.com/go-git/go-git/v5 v5.11.0/go.mod h1:6GFcX2P3NM7FPBfpePbpLd21XxsgdAt+lKqXmCUiUCY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -446,6 +451,7 @@ github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIG
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -691,6 +697,7 @@ github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuB
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -1393,10 +1400,12 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
 gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -178,7 +178,7 @@ var utilityProviders = map[string]ProviderVersion{
 	},
 	"okta-head": {
 		Source:  "okta/okta",
-		Version: ptr.String("~> 3.30"),
+		Version: ptr.String("> 3.30"),
 	},
 }
 

--- a/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -88,7 +88,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -88,7 +88,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/auth0_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/auth0_provider_yaml/terraform/global/fogg.tf
@@ -88,7 +88,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -101,7 +101,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -101,7 +101,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/bless_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/bless_provider_yaml/terraform/global/fogg.tf
@@ -101,7 +101,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/circleci/terraform/global/fogg.tf
+++ b/testdata/circleci/terraform/global/fogg.tf
@@ -77,7 +77,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/github_actions/terraform/global/fogg.tf
+++ b/testdata/github_actions/terraform/global/fogg.tf
@@ -77,7 +77,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -89,7 +89,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -89,7 +89,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/github_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/github_provider_yaml/terraform/global/fogg.tf
@@ -89,7 +89,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -89,7 +89,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -89,7 +89,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/okta_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/okta_provider_yaml/terraform/global/fogg.tf
@@ -89,7 +89,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/accounts/acct1/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/remote_backend_yaml/terraform/global/fogg.tf
+++ b/testdata/remote_backend_yaml/terraform/global/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -83,7 +83,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -83,7 +83,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/snowflake_provider_yaml/terraform/global/fogg.tf
@@ -83,7 +83,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_config/terraform/accounts/account/fogg.tf
+++ b/testdata/tfe_config/terraform/accounts/account/fogg.tf
@@ -113,7 +113,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_config/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/tfe_config/terraform/envs/staging/comp1/fogg.tf
@@ -115,7 +115,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_config/terraform/global/fogg.tf
+++ b/testdata/tfe_config/terraform/global/fogg.tf
@@ -113,7 +113,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_config/terraform/tfe/fogg.tf
+++ b/testdata/tfe_config/terraform/tfe/fogg.tf
@@ -113,7 +113,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -80,7 +80,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/envs/bar/bam/fogg.tf
@@ -77,7 +77,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/tfe_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/tfe_provider_yaml/terraform/global/fogg.tf
@@ -80,7 +80,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/bar/fogg.tf
@@ -437,7 +437,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/accounts/foo/fogg.tf
@@ -127,7 +127,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/datadog/fogg.tf
@@ -120,7 +120,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/hero/fogg.tf
@@ -128,7 +128,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/okta/fogg.tf
@@ -123,7 +123,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/sentry/fogg.tf
@@ -114,7 +114,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/prod/vpc/fogg.tf
@@ -111,7 +111,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -109,7 +109,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -109,7 +109,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/k8s-comp/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/k8s-comp/fogg.tf
@@ -127,7 +127,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -109,7 +109,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_full_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_full_yaml/terraform/global/fogg.tf
@@ -111,7 +111,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_minimal_valid_yaml/terraform/global/fogg.tf
@@ -77,7 +77,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/accounts/bar/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/accounts/bar/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/accounts/foo/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/accounts/foo/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp1/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp1/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp2/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/comp2/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/envs/staging/vpc/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 

--- a/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
+++ b/testdata/v2_no_aws_provider_yaml/terraform/global/fogg.tf
@@ -75,7 +75,7 @@ terraform {
     okta-head = {
       source = "okta/okta"
 
-      version = "~> 3.30"
+      version = "> 3.30"
 
     }
 


### PR DESCRIPTION
### Summary
the okta provider already has 4.x versions, so this small change will let us take advantage of them.

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
