### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/conventional_commits_title.yml
+++ b/.github/workflows/conventional_commits_title.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   conventional_commit_title:
-    runs-on: [self-hosted, ARM64, linux]
+    runs-on: ARM64
     steps:
       - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@main

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -9,7 +9,7 @@ concurrency:
     cancel-in-progress: true
 jobs:
   dependabot:
-    runs-on: [self-hosted, ARM64, linux]
+    runs-on: ARM64
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Generate token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 name: release-please
 jobs:
   release-please:
-    runs-on: [self-hosted, ARM64, linux]
+    runs-on: ARM64
     steps:
       - uses: actions/github-script@v5
         id: configure-changelog


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.