### PR TITLE
feat: CDI-4361 - Allow for admin teamprivilege type for TFE workspace

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Reporting Security Issues
+
+If you believe you have found a security issue, please responsibly disclose by contacting us at [security@chanzuckerberg.com](mailto:security@chanzuckerberg.com).

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -109,6 +109,7 @@ type TeamPermissions struct {
 	Plan  *[]string `json:"plan,omitempty"`
 	Read  *[]string `json:"read,omitempty"`
 	Write *[]string `json:"write,omitempty"`
+	Admin *[]string `json:"write,omitempty"`
 }
 type TFEWorkspace struct {
 	TriggerPrefixes         *[]string        `json:"trigger_prefixes,omitempty"`

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -109,7 +109,7 @@ type TeamPermissions struct {
 	Plan  *[]string `json:"plan,omitempty"`
 	Read  *[]string `json:"read,omitempty"`
 	Write *[]string `json:"write,omitempty"`
-	Admin *[]string `json:"write,omitempty"`
+	Admin *[]string `json:"admin,omitempty"`
 }
 type TFEWorkspace struct {
 	TriggerPrefixes         *[]string        `json:"trigger_prefixes,omitempty"`


### PR DESCRIPTION
### Summary
Fogg reverts any admin privilege grants to a tfe team currently: https://github.com/chanzuckerberg/shared-infra/pull/11302/commits/da3f2aa45bde3100a21439915e7250ff12bf92bc

### Test Plan
Say unittests, or list out steps to verify changes.

### References
(Optional) Additional links to provide more context.
