### PR TITLE
feat(ci): make terraform-docs gh-actions version configurable (default v1.0.0)

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -118,8 +118,9 @@ type CircleCI struct {
 type GitHubActionsCI struct {
 	CommonCI `yaml:",inline"`
 
-	SSHKeySecrets []string  `yaml:"ssh_key_secrets"`
-	RunsOn        *[]string `yaml:"runs_on,omitempty"`
+	SSHKeySecrets        []string  `yaml:"ssh_key_secrets"`
+	RunsOn               *[]string `yaml:"runs_on,omitempty"`
+	TerraformDocsVersion *string   `yaml:"terraform_docs_version,omitempty"`
 }
 
 type Env struct {

--- a/plan/ci.go
+++ b/plan/ci.go
@@ -30,8 +30,9 @@ type CircleCIConfig struct {
 
 type GitHubActionsCIConfig struct {
 	CIConfig
-	SSHKeySecrets []string
-	RunsOn        []string
+	SSHKeySecrets        []string
+	RunsOn               []string
+	TerraformDocsVersion string
 }
 
 type TravisCIConfig struct {
@@ -351,10 +352,20 @@ func (p *Plan) buildGitHubActionsConfig(c *v2.Config, foggVersion string) GitHub
 		runsOn = *c.Defaults.Tools.GitHubActionsCI.RunsOn
 	}
 
+	// Default kept at v1.0.0 for backwards compatibility; repos opt into a newer
+	// terraform-docs (e.g. for provider-defined functions) via terraform_docs_version.
+	terraformDocsVersion := "v1.0.0"
+	if c.Defaults.Tools != nil &&
+		c.Defaults.Tools.GitHubActionsCI != nil &&
+		c.Defaults.Tools.GitHubActionsCI.TerraformDocsVersion != nil {
+		terraformDocsVersion = *c.Defaults.Tools.GitHubActionsCI.TerraformDocsVersion
+	}
+
 	ciConfig = ciConfig.populateBuckets(numBuckets)
 	return GitHubActionsCIConfig{
-		CIConfig:      *ciConfig,
-		SSHKeySecrets: sshKeySecrets,
-		RunsOn:        runsOn,
+		CIConfig:             *ciConfig,
+		SSHKeySecrets:        sshKeySecrets,
+		RunsOn:               runsOn,
+		TerraformDocsVersion: terraformDocsVersion,
 	}
 }

--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -124,7 +124,7 @@ jobs:
         with:
           token: {{`${{ steps.generate_token.outputs.token }}`}}
       - name: fix terraform docs
-        uses: terraform-docs/gh-actions@v1.0.0
+        uses: terraform-docs/gh-actions@{{ $githubActionsCI.TerraformDocsVersion }}
         if: contains(matrix.tfmodule, 'modules') # only need to make docs on the modules
         with:
           working-dir: {{`${{matrix.tfmodule}}`}}

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
       - name: fix terraform docs
-        uses: terraform-docs/gh-actions@v1.0.0
+        uses: terraform-docs/gh-actions@v1.4.1
         if: contains(matrix.tfmodule, 'modules') # only need to make docs on the modules
         with:
           working-dir: ${{matrix.tfmodule}}

--- a/testdata/github_actions/fogg.yml
+++ b/testdata/github_actions/fogg.yml
@@ -13,6 +13,7 @@ defaults:
       command: lint
       enabled: true
       test_buckets: 7
+      terraform_docs_version: v1.4.1
       runs_on:
         - ARM64
 version: 2


### PR DESCRIPTION
## Why

`fogg_ci.yml`'s `fix terraform docs` step hardcodes **`terraform-docs/gh-actions@v1.0.0`** (terraform-docs v0.16.0), which predates Terraform **provider-defined functions** (TF 1.8) and can't parse `provider::<ns>::<fn>()`:

```
Error: ... Template interpolation doesn't expect a colon at this location ...
```

So any fogg-managed module that uses a provider function fails the lint job. But hard-bumping the version would force a terraform-docs upgrade — and README re-rendering — on **every** fogg repo.

## What (backwards-compatible)

Make the version an **opt-in config** instead of changing the default:

- `config`: `GitHubActionsCI.TerraformDocsVersion (*string)` → `tools.github_actions_ci.terraform_docs_version`
- `plan`: `GitHubActionsCIConfig.TerraformDocsVersion`, **defaulted to `v1.0.0`**
- `template`: `terraform-docs/gh-actions@{{ .TerraformDocsVersion }}`

**Default stays `v1.0.0`** → existing repos are unchanged (their goldens don't move). Repos that need provider functions set:

```yaml
tools:
  github_actions_ci:
    terraform_docs_version: v1.4.1
```

## Tests

- `testdata/github_actions` sets the override → golden renders `@v1.4.1`.
- `testdata/v2_full_yaml` + `…_no_default_providers` (no override) → stay `@v1.0.0` (backwards-compat proof).
- `go test ./config/... ./plan/... ./apply/...` green; goldens regenerated via `make update-golden-files`.

Verified terraform-docs ≥ v0.18 (bundled by gh-actions v1.4.1) parses provider functions; v0.16 (v1.0.0) does not.

Motivated by chanzuckerberg/argus-infra-stacks#2617 (a module needing `provider::corefunc::hash_sha1_base64` for an Envoy Gateway `{SHA}` htpasswd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)