### PR TITLE
fix(codegen): stop get-git-refs-hash.sh dying under set -e when no refs match

### DIFF
--- a/templates/templates/repo/scripts/get-git-refs-hash.sh
+++ b/templates/templates/repo/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/auth0_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/auth0_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/bless_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/bless_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/circleci/scripts/get-git-refs-hash.sh
+++ b/testdata/circleci/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/custom_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/custom_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/extra_gitignore_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/extra_gitignore_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/github_actions/scripts/get-git-refs-hash.sh
+++ b/testdata/github_actions/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/github_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/github_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/okta_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/okta_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/remote_backend_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/remote_backend_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/snowflake_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/snowflake_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/tfe_config/scripts/get-git-refs-hash.sh
+++ b/testdata/tfe_config/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/tfe_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/tfe_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/v2_full_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/v2_full_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/v2_full_yaml_no_default_providers/scripts/get-git-refs-hash.sh
+++ b/testdata/v2_full_yaml_no_default_providers/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/v2_minimal_valid_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/v2_minimal_valid_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2

--- a/testdata/v2_no_aws_provider_yaml/scripts/get-git-refs-hash.sh
+++ b/testdata/v2_no_aws_provider_yaml/scripts/get-git-refs-hash.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 git_refs=$(grep -E "module_source:.*\?ref=" fogg.yml | \
     sed -E 's/.*module_source: *//' | \
     grep -E "\?ref=" | \
-    sort -u)
+    sort -u || true)
 
 if [ -z "$git_refs" ]; then
     echo "No Git refs found in fogg.yml" >&2


### PR DESCRIPTION
## Problem

`scripts/get-git-refs-hash.sh` still fails in repos with no git-pinned module sources, even after #1217. The grep pipeline that extracts refs from `fogg.yml` returns non-zero when nothing matches. Under `set -euo pipefail` that fails the `git_refs=$(...)` assignment, and `set -e` exits the script immediately, before the empty-refs guard that #1217 added. The exit-0 path was therefore unreachable, so the "Get Git refs hash" CI step exited 1 with no output.

## Solution

Tolerate an empty match by appending `|| true` to the assignment pipeline. The script then reaches the existing guard, prints the sha256 of the empty string, and exits 0. Verified on bash 3.2 and 5.x.

Golden fixtures are regenerated.

## Testing

I built a binary from this branch and ran it against `biohub-onprem-backups-infra`, a repo with no git-pinned module sources, the same repo whose CI originally surfaced this bug.

I deleted the committed `scripts/get-git-refs-hash.sh` first, so fogg had to regenerate it from scratch. After `fogg apply` the script came back with mode `0755`, confirming the executable bit from #1217 survives a fresh write, and its assignment pipeline carried the new `|| true`.

Running the regenerated script in that no-refs repo exited 0 both ways. Invoked directly as `./scripts/get-git-refs-hash.sh` it printed the empty-string sha256 and exited 0, which exercises the executable bit and the first-line shebang. Invoked the way CI does, `hash=$(scripts/get-git-refs-hash.sh)`, it captured a clean `e3b0c442...` hash with the "No Git refs found" message going to stderr, so the message never pollutes the cache key.

The regenerated golden fixtures also pass `go test ./apply/...`.

## References

- Follows #1217, which added the empty-refs guard but left it unreachable.